### PR TITLE
[operators] add limit operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ Drop only the `event` field
 ```agrind
 * | json | where url != "/hostname"
 ```
+
+##### Limit
+`limit #`: Limit the number of rows to the given amount.  If the number is positive, only the 
+first N rows are returned.  If the number is negative, the last N rows are returned.
+
+*Examples*
+```agrind
+* | limit 10
+```
+```agrind
+* | limit -10
+```
+
 #### Aggregate Operators
 Aggregate operators group and combine your data by 0 or more key fields. The same query can include multiple aggregates.
 The general syntax is:

--- a/src/data.rs
+++ b/src/data.rs
@@ -20,7 +20,7 @@ pub struct Aggregate {
     pub data: Vec<VMap>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Record {
     pub data: VMap,
     pub raw: String,

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,7 +1,7 @@
 use crate::data;
 use nom;
 use nom::types::CompleteStr;
-use nom::{digit1, is_alphabetic, is_alphanumeric, is_digit, multispace};
+use nom::{digit1, is_alphabetic, is_alphanumeric, is_digit, double, multispace};
 use std::str;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -49,7 +49,7 @@ enum KeywordType {
 }
 
 /// Represents a `keyword` search string.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Keyword(String, KeywordType);
 
 impl Keyword {
@@ -93,7 +93,7 @@ pub enum Operator {
     Total(TotalOperator),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum InlineOperator {
     Json {
         input_column: Option<String>,
@@ -110,9 +110,14 @@ pub enum InlineOperator {
     Where {
         expr: Expr,
     },
+    Limit {
+        /// The count for the limit is pretty loosely typed at this point, the next phase will
+        /// check the value to see if it's sane or provide a default if no number was given.
+        count: Option<f64>,
+    }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum FieldMode {
     Only,
     Except,
@@ -250,6 +255,12 @@ named!(whre<CompleteStr, InlineOperator>, ws!(do_parse!(
     (InlineOperator::Where { expr: ex })
 )));
 
+named!(limit<CompleteStr, InlineOperator>, ws!(do_parse!(
+    tag!("limit") >>
+    count: opt!(double) >>
+    (InlineOperator::Limit{ count })
+)));
+
 named!(quoted_string <CompleteStr, &str>, delimited!(
     tag!("\""), 
     map!(escaped!(take_while1!(not_escape), '\\', one_of!("\"n\\")), |ref s|s.0),
@@ -347,7 +358,7 @@ named!(p_nn<CompleteStr, AggregateFunction>, ws!(
 ));
 
 named!(inline_operator<CompleteStr, Operator>,
-   map!(alt!(parse | json | fields | whre), Operator::Inline)
+   map!(alt!(parse | json | fields | whre | limit), Operator::Inline)
 );
 named!(aggregate_function<CompleteStr, AggregateFunction>, alt!(
     count_distinct |
@@ -580,6 +591,38 @@ mod tests {
                 fields: vec!["v".to_string()],
                 input_column: Some(Expr::Column("field".to_string())),
             },))
+        );
+    }
+
+    #[test]
+    fn parse_limit() {
+        expect!(
+            operator,
+            " limit",
+            Ok(Operator::Inline(InlineOperator::Limit {
+                count: None
+            }))
+        );
+        expect!(
+            operator,
+            " limit 5",
+            Ok(Operator::Inline(InlineOperator::Limit {
+                count: Some(5.0),
+            }))
+        );
+        expect!(
+            operator,
+            " limit -5",
+            Ok(Operator::Inline(InlineOperator::Limit {
+                count: Some(-5.0),
+            }))
+        );
+        expect!(
+            operator,
+            " limit 1e2",
+            Ok(Operator::Inline(InlineOperator::Limit {
+                count: Some(1e2),
+            }))
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,12 @@ mod render;
 mod typecheck;
 
 pub mod pipeline {
-    use crate::data::{Record, Row, Value};
+    use crate::data::{Record, Row};
     use crate::lang;
     use crate::lang::*;
     use crate::operator;
     use crate::render::{RenderConfig, Renderer};
-    use crate::typecheck;
-    use crossbeam_channel::{bounded, Receiver, RecvTimeoutError};
+    use crossbeam_channel::{bounded, Sender, Receiver, RecvTimeoutError};
     use failure::Error;
     use std::io::BufRead;
     use std::thread;
@@ -48,103 +47,7 @@ pub mod pipeline {
         renderer: Renderer,
     }
 
-    impl From<lang::ComparisonOp> for operator::BoolExpr {
-        fn from(op: ComparisonOp) -> Self {
-            match op {
-                ComparisonOp::Eq => operator::BoolExpr::Eq,
-                ComparisonOp::Neq => operator::BoolExpr::Neq,
-                ComparisonOp::Gt => operator::BoolExpr::Gt,
-                ComparisonOp::Lt => operator::BoolExpr::Lt,
-                ComparisonOp::Gte => operator::BoolExpr::Gte,
-                ComparisonOp::Lte => operator::BoolExpr::Lte,
-            }
-        }
-    }
-
-    impl From<lang::Expr> for operator::Expr {
-        fn from(inp: lang::Expr) -> Self {
-            match inp {
-                lang::Expr::Column(s) => operator::Expr::Column(s),
-                lang::Expr::Binary { op, left, right } => match op {
-                    BinaryOp::Comparison(com_op) => {
-                        operator::Expr::Comparison(operator::BinaryExpr::<operator::BoolExpr> {
-                            left: Box::new((*left).into()),
-                            right: Box::new((*right).into()),
-                            operator: com_op.into(),
-                        })
-                    }
-                },
-                lang::Expr::Value(value) => {
-                    let boxed = Box::new(value);
-                    let static_value: &'static mut Value = Box::leak(boxed);
-                    operator::Expr::Value(static_value)
-                }
-            }
-        }
-    }
-
     impl Pipeline {
-        fn convert_inline(
-            op: lang::InlineOperator,
-        ) -> Result<Box<operator::UnaryPreAggOperator>, operator::TypeError> {
-            match op {
-                InlineOperator::Json { input_column } => {
-                    Ok(Box::new(operator::ParseJson::new(input_column)))
-                }
-                InlineOperator::Parse {
-                    pattern,
-                    fields,
-                    input_column,
-                } => Ok(Box::new(operator::Parse::new(
-                    pattern.to_regex(),
-                    fields,
-                    input_column.map(|c| c.force()),
-                )?)),
-                InlineOperator::Fields { fields, mode } => {
-                    let omode = match mode {
-                        FieldMode::Except => operator::FieldMode::Except,
-                        FieldMode::Only => operator::FieldMode::Only,
-                    };
-                    Ok(Box::new(operator::Fields::new(&fields, omode)))
-                }
-                InlineOperator::Where { expr } => {
-                    let expr: operator::Expr = expr.into();
-                    typecheck::create_where(expr)
-                }
-            }
-        }
-
-        fn convert_inline_adapted(
-            op: lang::InlineOperator,
-        ) -> Result<Box<operator::AggregateOperator>, operator::TypeError> {
-            match op {
-                InlineOperator::Json { input_column } => {
-                    Ok(operator::ParseJson::new(input_column).into())
-                }
-                InlineOperator::Parse {
-                    pattern,
-                    fields,
-                    input_column,
-                } => Ok(operator::Parse::new(
-                    pattern.to_regex(),
-                    fields,
-                    input_column.map(|c| c.force()),
-                )?
-                .into()),
-                InlineOperator::Fields { fields, mode } => {
-                    let omode = match mode {
-                        FieldMode::Except => operator::FieldMode::Except,
-                        FieldMode::Only => operator::FieldMode::Only,
-                    };
-                    Ok(operator::Fields::new(&fields, omode).into())
-                }
-                InlineOperator::Where { expr } => {
-                    let expr: operator::Expr = expr.into();
-                    typecheck::create_where_adapt(expr)
-                }
-            }
-        }
-
         fn convert_total(op: lang::TotalOperator) -> Box<operator::AggregateOperator> {
             Box::new(operator::Total::new(op.input_column, op.output_column))
         }
@@ -214,10 +117,12 @@ pub mod pipeline {
             for op in query.operators {
                 match op {
                     Operator::Inline(inline_op) => {
+                        let op_builder = inline_op.semantic_analysis()?;
+
                         if !in_agg {
-                            pre_agg.push(Pipeline::convert_inline(inline_op)?);
+                            pre_agg.push(op_builder.to_preagg_operator());
                         } else {
-                            post_agg.push(Pipeline::convert_inline_adapted(inline_op)?)
+                            post_agg.push(Box::new(operator::PreAggAdapter::new(op_builder)));
                         }
                     }
                     Operator::MultiAggregate(agg_op) => {
@@ -242,7 +147,7 @@ pub mod pipeline {
                         max_buffer: 8,
                     },
                     Duration::from_millis(50),
-                ),
+                )
             })
         }
 
@@ -288,7 +193,7 @@ pub mod pipeline {
         pub fn process<T: BufRead>(self, mut buf: T) {
             let (tx, rx) = bounded(1000);
             let mut aggregators = self.aggregators;
-            let preaggs = self.pre_aggregates;
+            let mut preaggs = self.pre_aggregates;
             let renderer = self.renderer;
             let t = if !aggregators.is_empty() {
                 let head = aggregators.remove(0);
@@ -302,34 +207,55 @@ pub mod pipeline {
             // after we match (staying as Vec<u8> until then)
             let mut line = String::with_capacity(1024);
             while buf.read_line(&mut line).unwrap() > 0 {
-                if let Some(row) = Pipeline::proc_preagg(&line, &self.filter, &preaggs) {
-                    tx.send(row).unwrap();
+                if self.filter.iter().all(|re| re.is_match(&line)) {
+                    if !Pipeline::proc_preagg(Record::new(&line), &mut preaggs, &tx) {
+                        // One of the operators has closed, break out of the loop.
+                        break;
+                    }
                 }
                 line.clear();
             }
+
+            // Drain any remaining records from the operators.
+            while !preaggs.is_empty() {
+                let preagg = preaggs.remove(0);
+
+                for rec in preagg.drain() {
+                    if !Pipeline::proc_preagg(rec, &mut preaggs, &tx) {
+                        break;
+                    }
+                }
+            }
+
             // Drop tx when causes the thread to exit.
             drop(tx);
             t.join().unwrap();
         }
 
+        /// Process a record using the pre-agg operators.  The output of the last operator will be
+        /// sent to `tx`.
         fn proc_preagg(
-            s: &str,
-            filters: &[regex::Regex],
-            pre_aggs: &[Box<operator::UnaryPreAggOperator>],
-        ) -> Option<Row> {
-            if filters.iter().all(|re| re.is_match(s)) {
-                let mut rec = Record::new(s);
-                for pre_agg in pre_aggs {
-                    match (*pre_agg).process(rec) {
-                        Ok(Some(next_rec)) => rec = next_rec,
-                        Ok(None) => return None,
-                        Err(_) => return None,
-                    }
+            mut rec: Record,
+            pre_aggs: & mut [Box<operator::UnaryPreAggOperator>],
+            tx: & Sender<Row>)
+            -> bool {
+            let mut retval = true;
+
+            for pre_agg in pre_aggs {
+                match (*pre_agg).process(rec) {
+                    Ok(Some(next_rec)) => rec = next_rec,
+                    Ok(None) => return retval && pre_agg.is_open(),
+                    Err(err) => {
+                        eprintln!("error: {}", err);
+                        return retval && pre_agg.is_open();
+                    },
                 }
-                Some(Row::Record(rec))
-            } else {
-                None
+
+                retval = retval && pre_agg.is_open();
             }
+            tx.send(Row::Record(rec)).unwrap();
+
+            retval
         }
 
         pub fn run_agg_pipeline(

--- a/src/render.rs
+++ b/src/render.rs
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn pretty_print_record() {
         let rec = Record::new(r#"{"k1": 5, "k2": 5.5000001, "k3": "str"}"#);
-        let parser = ParseJson::new(None);
+        let mut parser = ParseJson::new(None);
         let rec = parser.process(rec).unwrap().unwrap();
         let mut pp = PrettyPrinter::new(
             RenderConfig {
@@ -343,20 +343,20 @@ mod tests {
         );
         assert_eq!(pp.format_record(&rec), "[k1=5]     [k2=5.50]    [k3=str]");
         let rec = Record::new(r#"{"k1": 955, "k2": 5.5000001, "k3": "str3"}"#);
-        let parser = ParseJson::new(None);
+        let mut parser = ParseJson::new(None);
         let rec = parser.process(rec).unwrap().unwrap();
         assert_eq!(pp.format_record(&rec), "[k1=955]   [k2=5.50]    [k3=str3]");
         let rec = Record::new(
             r#"{"k1": "here is a amuch longer stsring", "k2": 5.5000001, "k3": "str3"}"#,
         );
-        let parser = ParseJson::new(None);
+        let mut parser = ParseJson::new(None);
         let rec = parser.process(rec).unwrap().unwrap();
         assert_eq!(
             pp.format_record(&rec),
             "[k1=here is a amuch longer stsring]    [k2=5.50]    [k3=str3]"
         );
         let rec = Record::new(r#"{"k1": 955, "k2": 5.5000001, "k3": "str3"}"#);
-        let parser = ParseJson::new(None);
+        let mut parser = ParseJson::new(None);
         let rec = parser.process(rec).unwrap().unwrap();
         assert_eq!(
             pp.format_record(&rec),
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn pretty_print_record_too_long() {
         let rec = Record::new(r#"{"k1": 5, "k2": 5.5000001, "k3": "str"}"#);
-        let parser = ParseJson::new(None);
+        let mut parser = ParseJson::new(None);
         let rec = parser.process(rec).unwrap().unwrap();
         let mut pp = PrettyPrinter::new(
             RenderConfig {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1,24 +1,102 @@
-use crate::data::{FALSE_VALUE, TRUE_VALUE};
-use crate::operator::{AggregateOperator, Expr, TypeError, UnaryPreAggOperator, Where};
+use crate::lang;
+use crate::data::Value;
+use crate::operator;
 
-pub fn create_where(expr: Expr) -> Result<Box<UnaryPreAggOperator>, TypeError> {
-    match expr {
-        Expr::Comparison(binop) => Ok(Box::new(Where::new(binop))),
-        Expr::Value(t) if t == TRUE_VALUE => Ok(Box::new(Where::new(true))),
-        Expr::Value(t) if t == FALSE_VALUE => Ok(Box::new(Where::new(false))),
-        other => Err(TypeError::ExpectedBool {
-            found: format!("{:?}", other),
-        }),
+#[derive(Debug, Fail)]
+pub enum TypeError {
+    #[fail(display = "Expected boolean expression, found {}", found)]
+    ExpectedBool { found: String },
+
+    #[fail(display = "Wrong number of patterns for parse. Pattern has {} but {} were extracted",
+           pattern, extracted)]
+    ParseNumPatterns { pattern: usize, extracted: usize },
+
+    #[fail(display = "Limit must be a non-zero integer, found {}", limit)]
+    InvalidLimit { limit: f64 },
+}
+
+impl From<lang::ComparisonOp> for operator::BoolExpr {
+    fn from(op: lang::ComparisonOp) -> Self {
+        match op {
+            lang::ComparisonOp::Eq => operator::BoolExpr::Eq,
+            lang::ComparisonOp::Neq => operator::BoolExpr::Neq,
+            lang::ComparisonOp::Gt => operator::BoolExpr::Gt,
+            lang::ComparisonOp::Lt => operator::BoolExpr::Lt,
+            lang::ComparisonOp::Gte => operator::BoolExpr::Gte,
+            lang::ComparisonOp::Lte => operator::BoolExpr::Lte,
+        }
     }
 }
 
-pub fn create_where_adapt(expr: Expr) -> Result<Box<AggregateOperator>, TypeError> {
-    match expr {
-        Expr::Comparison(binop) => Ok(Where::new(binop).into()),
-        Expr::Value(t) if t == TRUE_VALUE => Ok(Where::new(true).into()),
-        Expr::Value(t) if t == FALSE_VALUE => Ok(Where::new(false).into()),
-        other => Err(TypeError::ExpectedBool {
-            found: format!("{:?}", other),
-        }),
+impl From<lang::Expr> for operator::Expr {
+    fn from(inp: lang::Expr) -> Self {
+        match inp {
+            lang::Expr::Column(s) => operator::Expr::Column(s),
+            lang::Expr::Binary { op, left, right } => match op {
+                lang::BinaryOp::Comparison(com_op) => {
+                    operator::Expr::Comparison(operator::BinaryExpr::<operator::BoolExpr> {
+                        left: Box::new((*left).into()),
+                        right: Box::new((*right).into()),
+                        operator: com_op.into(),
+                    })
+                }
+            },
+            lang::Expr::Value(value) => {
+                let boxed = Box::new(value);
+                let static_value: &'static mut Value = Box::leak(boxed);
+                operator::Expr::Value(static_value)
+            }
+        }
+    }
+}
+
+const DEFAULT_LIMIT: f64 = 10.0;
+
+impl lang::InlineOperator {
+    /// Convert the operator syntax to a builder that can instantiate an operator for the
+    /// pipeline.  Any semantic errors in the operator syntax should be detected here.
+    pub fn semantic_analysis(self) -> Result<Box<operator::OperatorBuilder + Send + Sync>,
+        TypeError> {
+        match self {
+            lang::InlineOperator::Json { input_column } =>
+                Ok(Box::new(operator::ParseJson::new(input_column))),
+            lang::InlineOperator::Parse { pattern, fields, input_column } => {
+                let regex = pattern.to_regex();
+
+                if (regex.captures_len() - 1) != fields.len() {
+                    Err(TypeError::ParseNumPatterns {
+                        pattern: regex.captures_len() - 1,
+                        extracted: fields.len(),
+                    })
+                } else {
+                    Ok(Box::new(operator::Parse::new(
+                        regex, fields, input_column.map(|e| e.into()))))
+                }
+            }
+            lang::InlineOperator::Fields { fields, mode } => {
+                let omode = match mode {
+                    lang::FieldMode::Except => operator::FieldMode::Except,
+                    lang::FieldMode::Only => operator::FieldMode::Only,
+                };
+                Ok(Box::new(operator::Fields::new(&fields, omode)))
+            }
+            lang::InlineOperator::Where { expr } => {
+                let oexpr = match expr.into() {
+                    operator::Expr::Comparison(binop) => binop,
+                    other => return Err(TypeError::ExpectedBool {
+                        found: format!("{:?}", other),
+                    })
+                };
+
+                Ok(Box::new(operator::Where::new(oexpr)))
+            }
+            lang::InlineOperator::Limit { count } => {
+                match count.unwrap_or(DEFAULT_LIMIT) as f64 {
+                    limit if limit.trunc() == 0.0 || limit.fract() != 0.0 =>
+                        Err(TypeError::InvalidLimit { limit }),
+                    limit => Ok(Box::new(operator::LimitDef::new(limit as i64))),
+                }
+            }
+        }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -207,6 +207,30 @@ $None$       1")
             .unwrap();
     }
 
+    #[test]
+    fn test_limit() {
+        assert_cli::Assert::main_binary()
+            .with_args(&[
+                r#"* | limit 2"#,
+                "--file",
+                "test_files/filter_test.log",
+            ])
+            .stdout()
+            .is("[INFO] I am a log!
+[WARN] Uh oh, danger ahead! ")
+            .unwrap();
+        assert_cli::Assert::main_binary()
+            .with_args(&[
+                r#"* | limit -2"#,
+                "--file",
+                "test_files/filter_test.log",
+            ])
+            .stdout()
+            .is("[INFO] Match a *STAR*!
+[INFO] Not a STAR! ")
+            .unwrap();
+    }
+
     fn ensure_parses(query: &str) {
         Pipeline::new(query).expect(&format!(
             "Query: `{}` from the README should have parsed",


### PR DESCRIPTION
One of the first operators I reached for after trying to use this
tool was 'limit'.  Fortunately, it wasn't implemented yet, so I
got to play around a bit (!).  I think the sumo syntax/semantics
allow for doing a "head" on the set of records.  But, since this
tool works on files, I figured a "tail" mode was necessary as
well.  So, I allow for the limit parameter to be negative to denote
a tail operation.  For example, to get the first 20 lines of a
file you would do:

  $ agrind -f /path/to/file '* | limit 20'

And, to get the last 20 lines:

  $ agrind -f /path/to/file '* | limit -20'

I had to make some non-trivial changes to the current design
to allow for limit to work:

  * Allow non-aggregate operators to maintain state since limit
    needs to keep a counter in "head" mode and a queue of records
    in tail mode.
  * Since non-agg operators now maintain state, the PreAggAdapter
    needs to re-instantiate the encapsulated operator to reset
    the state.  For example, if 'limit 5' is placed after an
    aggregate operator, we only want to show two lines of output
    from the aggregate.
  * The error checks done during pre-agg operators needs to be
    done separately since we don't want the to fail construction
    in the PreAggAdapter.
  * To allow limit to abort the pipeline before all of the input
    has been read, an is_open() method was added to the pre-agg
    operator trait.  Now, when an operator returns false for this
    method, the pipeline will break out of its main input loop.
  * To allow limit to return records after the main input loop,
    a drain() method was added to the pre-agg operator trait.
    After leaving the main input loop, the pipeline will drain()
    each operator and process the resulting set of records as it
    normally would.

If you think I am taking things in the wrong direction, let me know
and I can rework it.

Files:
  * Cargo.toml: Bump nom version to get the fixed version
    of the double function.
  * lang.rs: Add "limit" to the grammar.
  * lib.rs: Move the conversion of the types from the lang
    module to the typecheck module.  The idea being that
    lang builds the raw syntax tree and typecheck does the
    semantic analysis phase.  So, any errors should be
    caught in there.
  * operator.rs: Moved TypeError out to the typecheck mod.
    Add the Limit operator and definition (LimitDef).
    Changed the operator's process() method to take self
    as mutable so they can maintain state.  The operator
    constructors no longer return Result since the checks
    should now be done in the typecheck module.
  * typecheck.rs: Do more type checking in this module.