### PR TITLE
[operators] add limit operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Drop only the `event` field
 ```agrind
 * | json | where url != "/hostname"
 ```
+
+##### Limit
+`limit #`: Limit the number of rows to the given amount.
+
+*Examples*
+```agrind
+* | limit 10
+```
 #### Aggregate Operators
 Aggregate operators group and combine your data by 0 or more key fields. The same query can include multiple aggregates.
 The general syntax is:

--- a/src/data.rs
+++ b/src/data.rs
@@ -20,7 +20,7 @@ pub struct Aggregate {
     pub data: Vec<VMap>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Record {
     pub data: VMap,
     pub raw: String,

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -24,8 +24,8 @@ pub enum EvalError {
     #[fail(display = "Found None, expected {}", tpe)]
     UnexpectedNone { tpe: String },
 
-    #[fail(display = "Expected JSON")]
-    ExpectedJson,
+    #[fail(display = "Expected JSON, found {}", found)]
+    ExpectedJson { found: String },
 
     #[fail(display = "Expected string, found {}", found)]
     ExpectedString { found: String },
@@ -34,19 +34,7 @@ pub enum EvalError {
     ExpectedNumber { found: String },
 }
 
-#[derive(Debug, Fail)]
-pub enum TypeError {
-    #[fail(display = "Expected boolean expression, found {}", found)]
-    ExpectedBool { found: String },
-
-    #[fail(
-        display = "Wrong number of patterns for parse. Pattern has {} but {} were extracted",
-        pattern, extracted
-    )]
-    ParseNumPatterns { pattern: usize, extracted: usize },
-}
-
-pub trait Evaluatable<T> {
+pub trait Evaluatable<T>: Send + Sync + Clone {
     fn eval(&self, record: &Data) -> Result<T, EvalError>;
 }
 
@@ -54,37 +42,52 @@ pub trait EvaluatableBorrowed<T> {
     fn eval_borrowed<'a>(&self, record: &'a Data) -> Result<&'a T, EvalError>;
 }
 
-pub trait UnaryPreAggOperator: Send + Sync {
+/// Trait for operators that are functional in nature and do not maintain state.
+pub trait UnaryPreAggFunction: Send + Sync {
     fn process(&self, rec: Record) -> Result<Option<Record>, EvalError>;
-    fn process_mut(&mut self, rec: Record) -> Result<Option<Record>, EvalError> {
-        self.process(rec)
-    }
-    fn get_input<'a>(&self, rec: &'a Record, col: &Option<Expr>) -> Result<&'a str, EvalError> {
-        match col {
-            Some(expr) => {
-                let res: &String = expr.eval_borrowed(&rec.data)?;
-                Ok(res)
-            }
-            None => Ok(&rec.raw),
+}
+
+/// Get a column from the given record.
+fn get_input<'a>(rec: &'a Record, col: &Option<Expr>) -> Result<&'a str, EvalError> {
+    match col {
+        Some(expr) => {
+            let res: &String = expr.eval_borrowed(&rec.data)?;
+            Ok(res)
         }
+        None => Ok(&rec.raw),
     }
 }
 
-impl<'a, T: UnaryPreAggOperator + Send + Sync + 'a> From<T> for Box<AggregateOperator + 'a> {
-    fn from(op: T) -> Self {
-        Box::new(PreAggAdapter::new(op))
+/// Trait for operators that maintain state while processing records.
+pub trait UnaryPreAggOperator: Send + Sync {
+    fn process_mut(&mut self, rec: Record) -> Result<Option<Record>, EvalError>;
+}
+
+/// Trait used to instantiate an operator from its definition.  If an operator does not maintain
+/// state, the operator definition value can be cloned and returned.
+pub trait OperatorBuilder: Send + Sync {
+    fn build(&self) -> Box<UnaryPreAggOperator>;
+}
+
+/// A trivial OperatorBuilder implementation for functional traits since they don't need to
+/// maintain state.
+impl<T> OperatorBuilder for T
+    where T: 'static + UnaryPreAggFunction + Clone {
+    fn build(&self) -> Box<UnaryPreAggOperator> {
+        Box::new((*self).clone())
     }
 }
 
-pub struct PreAggAdapter<T: UnaryPreAggOperator + Send + Sync> {
-    op: T,
+/// Adapter for pre-aggregate operators to be used on the output of aggregate operators.
+pub struct PreAggAdapter {
+    op_supplier: Box<OperatorBuilder>,
     state: Aggregate,
 }
 
-impl<T: UnaryPreAggOperator + Send + Sync> PreAggAdapter<T> {
-    pub fn new(op: T) -> Self {
+impl PreAggAdapter {
+    pub fn new(op_supplier: Box<OperatorBuilder>) -> Self {
         PreAggAdapter {
-            op,
+            op_supplier,
             state: Aggregate {
                 columns: Vec::new(),
                 data: Vec::new(),
@@ -93,25 +96,25 @@ impl<T: UnaryPreAggOperator + Send + Sync> PreAggAdapter<T> {
     }
 }
 
-impl<T: UnaryPreAggOperator + Send + Sync> UnaryPreAggOperator for PreAggAdapter<T> {
-    fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
-        self.op.process(rec)
-    }
-
-    fn get_input<'a>(&self, rec: &'a Record, col: &Option<Expr>) -> Result<&'a str, EvalError> {
-        self.op.get_input(rec, col)
+/// A trivial UnaryPreAggOperator implementation for functional operators since they don't need
+/// an object to contain any state.
+impl<T> UnaryPreAggOperator for T
+    where T: UnaryPreAggFunction {
+    fn process_mut(&mut self, rec: Record) -> Result<Option<Record>, EvalError> {
+        self.process(rec)
     }
 }
 
-impl<T: UnaryPreAggOperator + Send + Sync> AggregateOperator for PreAggAdapter<T> {
+impl AggregateOperator for PreAggAdapter {
     fn emit(&self) -> Aggregate {
         self.state.clone()
     }
 
     fn process(&mut self, row: Row) {
         match row {
-            Row::Record(_) => panic!("PreAgg adaptor should only be used after aggregataes"),
+            Row::Record(_) => panic!("PreAgg adaptor should only be used after aggregates"),
             Row::Aggregate(agg) => {
+                let mut op = self.op_supplier.build();
                 let columns = agg.columns;
                 let processed_records: Vec<data::VMap> = {
                     let records = agg
@@ -121,7 +124,7 @@ impl<T: UnaryPreAggOperator + Send + Sync> AggregateOperator for PreAggAdapter<T
                             data: vmap,
                             raw: "".to_string(),
                         })
-                        .flat_map(|rec| self.op.process(rec).unwrap_or(None))
+                        .flat_map(|rec| op.process_mut(rec).unwrap_or(None))
                         .map(|rec| rec.data);
                     records.collect()
                 };
@@ -182,7 +185,7 @@ pub enum BoolExpr {
     Lte,
 }
 
-impl<T: Copy> Evaluatable<T> for T {
+impl<T: Copy + Send + Sync> Evaluatable<T> for T {
     fn eval(&self, _record: &HashMap<String, data::Value>) -> Result<T, EvalError> {
         Ok(*self)
     }
@@ -547,6 +550,7 @@ impl AggregateOperator for MultiGrouper {
     }
 }
 
+#[derive(Clone)]
 pub struct Parse {
     regex: regex::Regex,
     fields: Vec<String>,
@@ -558,23 +562,16 @@ impl Parse {
         pattern: regex::Regex,
         fields: Vec<String>,
         input_column: Option<Expr>,
-    ) -> Result<Self, TypeError> {
-        if (pattern.captures_len() - 1) != fields.len() {
-            Result::Err(TypeError::ParseNumPatterns {
-                pattern: pattern.captures_len() - 1,
-                extracted: fields.len(),
-            })
-        } else {
-            Result::Ok(Parse {
-                regex: pattern,
-                fields,
-                input_column,
-            })
+    ) -> Self {
+        Parse {
+            regex: pattern,
+            fields,
+            input_column,
         }
     }
 
     fn matches(&self, rec: &Record) -> Result<Option<Vec<data::Value>>, EvalError> {
-        let inp = self.get_input(rec, &self.input_column)?;
+        let inp = get_input(rec, &self.input_column)?;
         let matches: Vec<regex::Captures> = self.regex.captures_iter(inp.trim()).collect();
         if matches.is_empty() {
             Ok(None)
@@ -590,7 +587,7 @@ impl Parse {
     }
 }
 
-impl UnaryPreAggOperator for Parse {
+impl UnaryPreAggFunction for Parse {
     fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
         let matches = self.matches(&rec)?;
         match matches {
@@ -606,17 +603,18 @@ impl UnaryPreAggOperator for Parse {
     }
 }
 
-pub struct Where<T: Evaluatable<bool> + Send + Sync> {
+#[derive(Clone)]
+pub struct Where<T: 'static + Evaluatable<bool>> {
     expr: T,
 }
 
-impl<T: Evaluatable<bool> + Send + Sync> Where<T> {
+impl<T: 'static + Evaluatable<bool>> Where<T> {
     pub fn new(expr: T) -> Self {
         Where { expr }
     }
 }
 
-impl<T: Evaluatable<bool> + Send + Sync> UnaryPreAggOperator for Where<T> {
+impl<T: 'static + Evaluatable<bool>> UnaryPreAggFunction for Where<T> {
     fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
         if self.expr.eval(&rec.data)? {
             Ok(Some(rec))
@@ -705,11 +703,13 @@ impl AggregateOperator for Total {
     }
 }
 
+#[derive(Clone)]
 pub enum FieldMode {
     Only,
     Except,
 }
 
+#[derive(Clone)]
 pub struct Fields {
     columns: HashSet<String>,
     mode: FieldMode,
@@ -722,7 +722,7 @@ impl Fields {
     }
 }
 
-impl UnaryPreAggOperator for Fields {
+impl UnaryPreAggFunction for Fields {
     fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
         let mut rec = rec;
         match self.mode {
@@ -741,6 +741,7 @@ impl UnaryPreAggOperator for Fields {
     }
 }
 
+#[derive(Clone)]
 pub struct ParseJson {
     input_column: Option<Expr>,
 }
@@ -753,11 +754,13 @@ impl ParseJson {
     }
 }
 
-impl UnaryPreAggOperator for ParseJson {
+impl UnaryPreAggFunction for ParseJson {
     fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
         let json: JsonValue = {
-            let inp = self.get_input(&rec, &self.input_column)?;
-            serde_json::from_str(&inp).map_err(|_| EvalError::ExpectedJson)?
+            let inp = get_input(&rec, &self.input_column)?;
+            serde_json::from_str(&inp).map_err(|_| EvalError::ExpectedJson{
+                found: inp.trim_end().to_string()
+            })?
         };
         let res = match json {
             JsonValue::Object(map) => map.iter().fold(Some(rec), |record_opt, (k, v)| {
@@ -780,6 +783,55 @@ impl UnaryPreAggOperator for ParseJson {
             _other => Some(rec),
         };
         Ok(res)
+    }
+}
+
+/// The definition for a limit operator, which is a positive or negative number used to specify
+/// whether the first number of rows should be passed through or the last number of rows,
+/// respectively.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct LimitDef {
+    limit: i64,
+}
+
+impl LimitDef {
+    pub fn new(limit: i64) -> Self {
+        LimitDef { limit }
+    }
+}
+
+/// The state for a limit operator
+pub enum Limit {
+    Head {
+        /// The current index into the input stream.
+        index: u64,
+        /// The number of rows to pass through before aborting.
+        limit: u64,
+    },
+}
+
+impl OperatorBuilder for LimitDef {
+    fn build(&self) -> Box<UnaryPreAggOperator> {
+        Box::new(Limit::Head {
+            index: 0,
+            limit: self.limit as u64,
+        })
+    }
+}
+
+impl UnaryPreAggOperator for Limit {
+    fn process_mut(&mut self, rec: Record) -> Result<Option<Record>, EvalError> {
+        match self {
+            Limit::Head { ref mut index, limit } => {
+                (*index) += 1;
+
+                if index <= limit {
+                    Ok(Some(rec))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
     }
 }
 
@@ -867,8 +919,7 @@ mod tests {
                 "length".to_string(),
             ],
             None,
-        )
-        .unwrap();
+        );
         let rec = parser.process(rec).unwrap().unwrap();
         assert_eq!(
             rec.data.get("sender").unwrap(),
@@ -888,9 +939,8 @@ mod tests {
         let parser = Parse::new(
             lang::Keyword::new_wildcard("[*=*]".to_string()).to_regex(),
             vec!["key".to_string(), "value".to_string()],
-            Some("from_col".into()),
-        )
-        .unwrap();
+            Some("from_col".into())
+        );
         let rec = parser.process(rec).unwrap().unwrap();
         assert_eq!(
             rec.data.get("key").unwrap(),
@@ -1079,7 +1129,7 @@ mod tests {
     #[test]
     fn test_agg_adapter() {
         let where_op = Where::new(true);
-        let adapted = PreAggAdapter::new(where_op);
+        let adapted = PreAggAdapter::new(Box::new(where_op));
         let mut adapted: Box<AggregateOperator> = Box::new(adapted);
         let agg = Aggregate::new(
             &["kc1".to_string(), "kc2".to_string()],

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -1,24 +1,102 @@
-use crate::data::{FALSE_VALUE, TRUE_VALUE};
-use crate::operator::{AggregateOperator, Expr, TypeError, UnaryPreAggOperator, Where};
+use crate::lang;
+use crate::data::Value;
+use crate::operator;
 
-pub fn create_where(expr: Expr) -> Result<Box<UnaryPreAggOperator>, TypeError> {
-    match expr {
-        Expr::Comparison(binop) => Ok(Box::new(Where::new(binop))),
-        Expr::Value(t) if t == TRUE_VALUE => Ok(Box::new(Where::new(true))),
-        Expr::Value(t) if t == FALSE_VALUE => Ok(Box::new(Where::new(false))),
-        other => Err(TypeError::ExpectedBool {
-            found: format!("{:?}", other),
-        }),
+#[derive(Debug, Fail)]
+pub enum TypeError {
+    #[fail(display = "Expected boolean expression, found {}", found)]
+    ExpectedBool { found: String },
+
+    #[fail(display = "Wrong number of patterns for parse. Pattern has {} but {} were extracted",
+           pattern, extracted)]
+    ParseNumPatterns { pattern: usize, extracted: usize },
+
+    #[fail(display = "Limit must be an integer that is greater than zero, found {}", limit)]
+    InvalidLimit { limit: f64 },
+}
+
+impl From<lang::ComparisonOp> for operator::BoolExpr {
+    fn from(op: lang::ComparisonOp) -> Self {
+        match op {
+            lang::ComparisonOp::Eq => operator::BoolExpr::Eq,
+            lang::ComparisonOp::Neq => operator::BoolExpr::Neq,
+            lang::ComparisonOp::Gt => operator::BoolExpr::Gt,
+            lang::ComparisonOp::Lt => operator::BoolExpr::Lt,
+            lang::ComparisonOp::Gte => operator::BoolExpr::Gte,
+            lang::ComparisonOp::Lte => operator::BoolExpr::Lte,
+        }
     }
 }
 
-pub fn create_where_adapt(expr: Expr) -> Result<Box<AggregateOperator>, TypeError> {
-    match expr {
-        Expr::Comparison(binop) => Ok(Where::new(binop).into()),
-        Expr::Value(t) if t == TRUE_VALUE => Ok(Where::new(true).into()),
-        Expr::Value(t) if t == FALSE_VALUE => Ok(Where::new(false).into()),
-        other => Err(TypeError::ExpectedBool {
-            found: format!("{:?}", other),
-        }),
+impl From<lang::Expr> for operator::Expr {
+    fn from(inp: lang::Expr) -> Self {
+        match inp {
+            lang::Expr::Column(s) => operator::Expr::Column(s),
+            lang::Expr::Binary { op, left, right } => match op {
+                lang::BinaryOp::Comparison(com_op) => {
+                    operator::Expr::Comparison(operator::BinaryExpr::<operator::BoolExpr> {
+                        left: Box::new((*left).into()),
+                        right: Box::new((*right).into()),
+                        operator: com_op.into(),
+                    })
+                }
+            },
+            lang::Expr::Value(value) => {
+                let boxed = Box::new(value);
+                let static_value: &'static mut Value = Box::leak(boxed);
+                operator::Expr::Value(static_value)
+            }
+        }
+    }
+}
+
+const DEFAULT_LIMIT: f64 = 10.0;
+
+impl lang::InlineOperator {
+    /// Convert the operator syntax to a builder that can instantiate an operator for the
+    /// pipeline.  Any semantic errors in the operator syntax should be detected here.
+    pub fn semantic_analysis(self) -> Result<Box<operator::OperatorBuilder + Send + Sync>,
+        TypeError> {
+        match self {
+            lang::InlineOperator::Json { input_column } =>
+                Ok(Box::new(operator::ParseJson::new(input_column))),
+            lang::InlineOperator::Parse { pattern, fields, input_column } => {
+                let regex = pattern.to_regex();
+
+                if (regex.captures_len() - 1) != fields.len() {
+                    Err(TypeError::ParseNumPatterns {
+                        pattern: regex.captures_len() - 1,
+                        extracted: fields.len(),
+                    })
+                } else {
+                    Ok(Box::new(operator::Parse::new(
+                        regex, fields, input_column.map(|e| e.into()))))
+                }
+            }
+            lang::InlineOperator::Fields { fields, mode } => {
+                let omode = match mode {
+                    lang::FieldMode::Except => operator::FieldMode::Except,
+                    lang::FieldMode::Only => operator::FieldMode::Only,
+                };
+                Ok(Box::new(operator::Fields::new(&fields, omode)))
+            }
+            lang::InlineOperator::Where { expr } => {
+                let oexpr = match expr.into() {
+                    operator::Expr::Comparison(binop) => binop,
+                    other => return Err(TypeError::ExpectedBool {
+                        found: format!("{:?}", other),
+                    })
+                };
+
+                Ok(Box::new(operator::Where::new(oexpr)))
+            }
+            lang::InlineOperator::Limit { count } => {
+                match count.unwrap_or(DEFAULT_LIMIT) as f64 {
+                    limit if limit.trunc() <= 0.0 || limit.fract() != 0.0 =>
+                        Err(TypeError::InvalidLimit { limit }),
+                    limit => Ok(Box::new(operator::LimitDef::new(limit as i64))),
+                }
+            }
+        }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -67,6 +67,11 @@ mod integration {
     }
 
     #[test]
+    fn limit() {
+        structured_test(include_str!("structured_tests/limit.toml"));
+    }
+
+    #[test]
     fn no_args() {
         assert_cli::Assert::main_binary()
             .fails()
@@ -203,6 +208,20 @@ $None$       1")
             .stdout()
             .is("[INFO] Match a *STAR*!
 [INFO] Not a STAR!")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_limit() {
+        assert_cli::Assert::main_binary()
+            .with_args(&[
+                r#"* | limit 2"#,
+                "--file",
+                "test_files/filter_test.log",
+            ])
+            .stdout()
+            .is("[INFO] I am a log!
+[WARN] Uh oh, danger ahead! ")
             .unwrap();
     }
 

--- a/tests/structured_tests/limit.toml
+++ b/tests/structured_tests/limit.toml
@@ -1,0 +1,13 @@
+query = "* | limit 2"
+input = """
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": "error", "message": "Oh now an error!"}
+{"level": "error", "message": "So many more errors!", "num_things": 0.1}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A different event", "event_duration": 1002.5}
+{"level": null}
+"""
+output = """
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": "error", "message": "Oh now an error!"}
+"""


### PR DESCRIPTION
One of the first operators I reached for after trying to use this
tool was 'limit'.  Fortunately, it wasn't implemented yet, so I
got to play around a bit (!).  This change contains the first part
of the limit implementation, which passes records through up to
the limit and then drops the remaining records.  In a followup
change, I'll address aborting the upstream after the limit has
been reached so we don't have to read until the end of the input
stream.

I had to make some non-trivial changes to the current design
to allow for limit to work:

  * Allow non-aggregate operators to maintain state since limit
    needs to keep a counter in "head" mode.
  * Since non-agg operators now maintain state, the PreAggAdapter
    needs to re-instantiate the encapsulated operator to reset
    the state.  For example, if 'limit 5' is placed after an
    aggregate operator, we only want to show two lines of output
    from the aggregate.  To do this, an OperatorBuilder trait has
    been added that can be used to construct the mutable operator
    state from the operator definition.
  * The existing operators have been changed to implement a new
    UnaryPreAggFunction trait since they do not maintain state and
    it's easier to create a generic OperatorBuilder for these types
    of traits.
  * The error checks done during pre-agg operators needs to be
    done separately since we don't want them to fail construction
    in the PreAggAdapter.

I haven't fixed the issue with a limit operator after an aggregate
since I don't have a feel for what the best design might be when
an automatic sort should be inserted.

If you think I am taking things in the wrong direction, let me know
and I can rework it.

Files:
  * lang.rs: Add "limit" to the grammar.
  * lib.rs: Move the conversion of the types from the lang
    module to the typecheck module.  The idea being that
    lang builds the raw syntax tree and typecheck does the
    semantic analysis phase.  So, any errors should be
    caught in there.
  * operator.rs: Moved TypeError out to the typecheck mod.
    Add the Limit operator and definition (LimitDef).
    Changed the operator's process() method to take self
    as mutable so they can maintain state.  The operator
    constructors no longer return Result since the checks
    should now be done in the typecheck module.
  * typecheck.rs: Do more type checking in this module.