### PR TITLE
Add the default sort between aggregates and limits

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,8 +1,8 @@
 use crate::data;
 use nom;
+use nom::types::CompleteStr;
 use nom::*;
 use nom::{digit1, double, is_alphabetic, is_alphanumeric, is_digit, multispace};
-use nom::types::CompleteStr;
 use std::str;
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,14 +122,14 @@ pub mod pipeline {
                         let needs_sort = match op_iter.peek() {
                             Some(Operator::Inline(InlineOperator::Limit { .. })) => true,
                             None => true,
-                            _ => false
+                            _ => false,
                         };
                         if needs_sort {
                             post_agg.push(Pipeline::convert_sort(sorter));
                         }
                     }
                     Operator::Sort(sort_op) => post_agg.push(Pipeline::convert_sort(sort_op)),
-                    Operator::Total(total_op) => post_agg.push(Pipeline::convert_total(total_op))
+                    Operator::Total(total_op) => post_agg.push(Pipeline::convert_total(total_op)),
                 }
             }
             Result::Ok(Pipeline {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -69,6 +69,7 @@ mod integration {
     #[test]
     fn limit() {
         structured_test(include_str!("structured_tests/limit.toml"));
+        structured_test(include_str!("structured_tests/limit_agg.toml"));
     }
 
     #[test]

--- a/tests/structured_tests/limit_agg.toml
+++ b/tests/structured_tests/limit_agg.toml
@@ -1,0 +1,27 @@
+query = "* | json | count by level | limit 1"
+input = """
+{"level": "error", "message": "Oh now an error!"}
+{"level": "error", "message": "So many more errors!", "num_things": 0.1}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A different event", "event_duration": 1002.5}
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": null}
+"""
+output = """
+level        _count
+---------------------------
+info         15
+"""
+notes = "If the implicit sort operator isn't added after the count, the output will be `error` and not `info`"


### PR DESCRIPTION
@tstack this adds the default sort between aggregates and limits -- I played around with it a bit and the results seemed reasonable. Let me know if you encountered other issues in testing that seemed wrong.