### PR TITLE
[operators] limit operator part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,17 @@ Drop only the `event` field
 ```
 
 ##### Limit
-`limit #`: Limit the number of rows to the given amount.
+`limit #`: Limit the number of rows to the given amount.  If the number is positive, only the 
+first N rows are returned.  If the number is negative, the last N rows are returned.
 
 *Examples*
 ```agrind
 * | limit 10
 ```
+```agrind
+* | limit -10
+```
+
 #### Aggregate Operators
 Aggregate operators group and combine your data by 0 or more key fields. The same query can include multiple aggregates.
 The general syntax is:

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -65,7 +65,7 @@ pub trait UnaryPreAggOperator: Send + Sync {
     fn process_mut(&mut self, rec: Record) -> Result<Option<Record>, EvalError>;
     /// Return any remaining records that may have been gathered by the operator.  This method
     /// will be called when there are no more new input records.
-    fn drain(self: Box<Self>) -> Box<Iterator<Item=Record>> {
+    fn drain(self: Box<Self>) -> Box<Iterator<Item = Record>> {
         Box::new(iter::empty())
     }
 }
@@ -822,12 +822,12 @@ pub enum Limit {
         /// The size of the circular buffer.
         /// XXX Might be better to use a separate type.
         limit: usize,
-    }
+    },
 }
 
 impl OperatorBuilder for LimitDef {
     fn build(&self) -> Box<UnaryPreAggOperator> {
-         Box::new(if self.limit > 0 {
+        Box::new(if self.limit > 0 {
             Limit::Head {
                 index: 0,
                 limit: self.limit as u64,
@@ -856,18 +856,21 @@ impl UnaryPreAggOperator for Limit {
                     Ok(None)
                 }
             }
-            Limit::Tail { ref mut queue, limit } => {
+            Limit::Tail {
+                ref mut queue,
+                limit,
+            } => {
                 if queue.len() == *limit {
                     queue.pop_front();
                 }
                 queue.push_back(rec);
 
-                 Ok(None)
+                Ok(None)
             }
         }
     }
 
-    fn drain(self: Box<Self>) -> Box<Iterator<Item=Record>> {
+    fn drain(self: Box<Self>) -> Box<Iterator<Item = Record>> {
         match *self {
             Limit::Head { .. } => Box::new(iter::empty()),
             Limit::Tail { queue, .. } => Box::new(queue.into_iter()),

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -128,7 +128,7 @@ impl AggregateOperator for PreAggAdapter {
             Row::Aggregate(agg) => {
                 let mut op = self.op_builder.build();
                 let columns = agg.columns;
-                let processed_records: Vec<data::VMap> = {
+                let mut processed_records: Vec<data::VMap> = {
                     let records = agg
                         .data
                         .into_iter()
@@ -140,6 +140,7 @@ impl AggregateOperator for PreAggAdapter {
                         .map(|rec| rec.data);
                     records.collect()
                 };
+                processed_records.extend(op.drain().map(|rec| rec.data));
                 let new_keys: Vec<String> = {
                     processed_records
                         .iter()

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -13,10 +13,7 @@ pub enum TypeError {
     )]
     ParseNumPatterns { pattern: usize, extracted: usize },
 
-    #[fail(
-        display = "Limit must be a non-zero integer, found {}",
-        limit
-    )]
+    #[fail(display = "Limit must be a non-zero integer, found {}", limit)]
     InvalidLimit { limit: f64 },
 }
 
@@ -100,7 +97,7 @@ impl lang::InlineOperator {
                     other => {
                         return Err(TypeError::ExpectedBool {
                             found: format!("{:?}", other),
-                        })
+                        });
                     }
                 };
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -14,7 +14,7 @@ pub enum TypeError {
     ParseNumPatterns { pattern: usize, extracted: usize },
 
     #[fail(
-        display = "Limit must be an integer that is greater than zero, found {}",
+        display = "Limit must be a non-zero integer, found {}",
         limit
     )]
     InvalidLimit { limit: f64 },
@@ -107,7 +107,7 @@ impl lang::InlineOperator {
                 Ok(Box::new(operator::Where::new(oexpr)))
             }
             lang::InlineOperator::Limit { count } => match count.unwrap_or(DEFAULT_LIMIT) as f64 {
-                limit if limit.trunc() <= 0.0 || limit.fract() != 0.0 => {
+                limit if limit.trunc() == 0.0 || limit.fract() != 0.0 => {
                     Err(TypeError::InvalidLimit { limit })
                 }
                 limit => Ok(Box::new(operator::LimitDef::new(limit as i64))),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -71,6 +71,7 @@ mod integration {
         structured_test(include_str!("structured_tests/limit.toml"));
         structured_test(include_str!("structured_tests/limit_tail.toml"));
         structured_test(include_str!("structured_tests/limit_agg.toml"));
+        structured_test(include_str!("structured_tests/limit_agg_tail.toml"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -69,6 +69,7 @@ mod integration {
     #[test]
     fn limit() {
         structured_test(include_str!("structured_tests/limit.toml"));
+        structured_test(include_str!("structured_tests/limit_tail.toml"));
         structured_test(include_str!("structured_tests/limit_agg.toml"));
     }
 
@@ -101,6 +102,24 @@ mod integration {
             .and()
             .stderr()
             .contains("Expected boolean expression, found")
+            .unwrap();
+    }
+
+    #[test]
+    fn test_limit_typecheck() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["* | limit 0"])
+            .fails()
+            .and()
+            .stderr()
+            .contains("Error: Limit must be a non-zero integer, found 0")
+            .unwrap();
+        assert_cli::Assert::main_binary()
+            .with_args(&["* | limit 0.1"])
+            .fails()
+            .and()
+            .stderr()
+            .contains("Error: Limit must be a non-zero integer, found 0.1")
             .unwrap();
     }
 

--- a/tests/structured_tests/limit.toml
+++ b/tests/structured_tests/limit.toml
@@ -1,4 +1,4 @@
-query = "* | limit -2"
+query = "* | limit 2"
 input = """
 {"level": "info", "message": "A thing happened", "num_things": 1102}
 {"level": "error", "message": "Oh now an error!"}
@@ -8,6 +8,6 @@ input = """
 {"level": null}
 """
 output = """
-{"level": "info", "message": "A different event", "event_duration": 1002.5}
-{"level": null}
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": "error", "message": "Oh now an error!"}
 """

--- a/tests/structured_tests/limit_agg_tail.toml
+++ b/tests/structured_tests/limit_agg_tail.toml
@@ -1,0 +1,27 @@
+query = "* | json | count by level | limit -1"
+input = """
+{"level": "error", "message": "Oh now an error!"}
+{"level": "error", "message": "So many more errors!", "num_things": 0.1}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A different event", "event_duration": 1002.5}
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": null}
+"""
+output = """
+level         _count
+----------------------------
+$None$        1
+"""
+notes = "If the implicit sort operator isn't added after the count, the output will be `error` and not `info`"

--- a/tests/structured_tests/limit_tail.toml
+++ b/tests/structured_tests/limit_tail.toml
@@ -1,4 +1,4 @@
-query = "* | limit -2"
+query = "* | limit 2"
 input = """
 {"level": "info", "message": "A thing happened", "num_things": 1102}
 {"level": "error", "message": "Oh now an error!"}
@@ -8,6 +8,6 @@ input = """
 {"level": null}
 """
 output = """
-{"level": "info", "message": "A different event", "event_duration": 1002.5}
-{"level": null}
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": "error", "message": "Oh now an error!"}
 """

--- a/tests/structured_tests/limit_tail.toml
+++ b/tests/structured_tests/limit_tail.toml
@@ -1,4 +1,4 @@
-query = "* | limit 2"
+query = "* | limit -2"
 input = """
 {"level": "info", "message": "A thing happened", "num_things": 1102}
 {"level": "error", "message": "Oh now an error!"}
@@ -8,6 +8,6 @@ input = """
 {"level": null}
 """
 output = """
-{"level": "info", "message": "A thing happened", "num_things": 1102}
-{"level": "error", "message": "Oh now an error!"}
+{"level": "info", "message": "A different event", "event_duration": 1002.5}
+{"level": null}
 """


### PR DESCRIPTION
This change adds the "tail" mode for the limit operator to
allow for the selection of the last set of rows instead of
the first set of rows.

Files:
  * README.md: Doc the tail mode of limit.
  * lib.rs: Drain the operators and process the resulting
    documents.
  * operators.rs: Add the drain() method and the new tail
    mode for limit.
  * typecheck.rs: Allow a negative limit.
  * integration.rs: Add tests for the tail functionality.