### PR TITLE
[lang] first cut at improving parse error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ag"
 version = "0.8.2"
 dependencies = [
+ "annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -22,6 +23,9 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom_locate 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quantiles 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -42,6 +46,14 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -127,6 +139,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "build_const"
 version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bytecount"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -859,6 +876,27 @@ version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nom_locate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytecount 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1950,6 +1988,7 @@ dependencies = [
 "checksum MacTypes-sys 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7dbbe033994ae2198a18517c7132d952a29fb1db44249a1234779da7c50f4698"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e8bcdcd5b291ce85a78f2b9d082a8de9676c12b1840d386d67bc5eea6f9d2b4e"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a29ab7c0ed62970beb0534d637a8688842506d0ff9157de83286dacd065c8149"
@@ -1960,6 +1999,7 @@ dependencies = [
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
+"checksum bytecount 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f861d9ce359f56dbcb6e0c2a1cb84e52ad732cadb57b806adeb3c7668caccbd8"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
@@ -2041,6 +2081,8 @@ dependencies = [
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
+"checksum nom_locate 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6a47c112b3861d81f7fbf73892b9271af933af32bd5dee6889aa3c3fa9caed7e"
+"checksum num-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8af1847c907c2f04d7bfd572fb25bbb4385c637fe5be163cf2f8c5d778fe1e7d"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
 "checksum openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ec7bd7ca4cce6dbdc77e7c1230682740d307d1218a87fb0349a571272be749f9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,7 @@ version = "0.8.2"
 dependencies = [
  "annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,8 @@ extended-description = """Angle-grinder allows you to parse, aggregate, sum, ave
 [dependencies]
 serde_json = "1.0.33"
 itertools = "0.8.0"
-nom = "4.1.1"
+nom = { version = "4.1.1", features = ["verbose-errors"] }
+nom_locate = { version = "0.3.1", features = ["verbose-errors"] }
 quicli = "0.4.0"
 regex = "1.1.0"
 terminal_size = "0.1.8"
@@ -30,6 +31,9 @@ failure = "0.1.3"
 structopt = "0.2"
 human-panic = "1.0.1"
 self_update = "0.5.0"
+num-derive = "0.2.3"
+num-traits = "0.2.6"
+annotate-snippets = { version = "0.5.0", features = ["ansi_term"] }
 
 [dev-dependencies]
 assert_cli = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ self_update = "0.5.0"
 num-derive = "0.2.3"
 num-traits = "0.2.6"
 annotate-snippets = { version = "0.5.0", features = ["ansi_term"] }
+atty = "0.2.0"
 
 [dev-dependencies]
 assert_cli = "0.6.3"

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Ideally, any errors should explain the problem, point the user to the relevant p
 string, and lead the user to a solution.
 Using the `ErrorBuilder`, you can call the `new_error_report_for()` method to construct a 
 `SnippetBuilder` for a given error.
-To highlight a portion of the query string, use the `with_annotation()` method with the
+To highlight a portion of the query string, use the `with_code_pointer()` method with the
 `Positioned` object that refers to the relevant segment of the query string.
 Finally, additional help/examples can be added by calling the `with_resolution()` method.
 

--- a/src/bin/agrind.rs
+++ b/src/bin/agrind.rs
@@ -1,5 +1,6 @@
 use ag::pipeline::{ErrorReporter, Pipeline, QueryContainer};
 use annotate_snippets::snippet::Snippet;
+use atty::Stream;
 use human_panic::setup_panic;
 use quicli::prelude::*;
 use self_update;
@@ -67,7 +68,7 @@ fn main() -> CliResult {
         args.query.ok_or(InvalidArgs::MissingQuery)?,
         Box::new(TermErrorReporter {
             formatter: annotate_snippets::formatter::DisplayListFormatter::new(
-                env::var("NO_COLOR").is_err(),
+                env::var("NO_COLOR").is_err() && atty::is(Stream::Stderr),
             ),
         }),
     );

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,7 +51,7 @@ impl QueryContainer {
                         (ref start_span, ErrorKind::Custom(SyntaxErrors::DelimiterStart)),
                     )) => {
                         self.report_error_for(delim_error)
-                            .with_annotation_range((*start_span).into(), (*end_span).into(), "")
+                            .with_code_range((*start_span).into(), (*end_span).into(), "")
                             .with_resolutions(delim_error.to_resolution())
                             .send_report();
                     }
@@ -60,7 +60,7 @@ impl QueryContainer {
             }
             Err(nom::Err::Error(nom::Context::Code(span, _))) => {
                 self.report_error_for("Unexpected input")
-                    .with_annotation_range(span.into(), QueryPosition(self.query.len()), "")
+                    .with_code_range(span.into(), QueryPosition(self.query.len()), "")
                     .send_report();
             }
             _ => (),
@@ -140,7 +140,7 @@ pub struct SnippetBuilder<'a> {
 impl<'a> SnippetBuilder<'a> {
     /// Adds an annotation to a portion of the query string.  The given position will be
     /// highlighted with the accompanying label.
-    pub fn with_annotation<T, S: ToString>(mut self, pos: &Positioned<T>, label: S) -> Self {
+    pub fn with_code_pointer<T, S: ToString>(mut self, pos: &Positioned<T>, label: S) -> Self {
         self.data
             .annotations
             .push(((pos.start_pos.0, pos.end_pos.0), label.to_string()));
@@ -149,7 +149,7 @@ impl<'a> SnippetBuilder<'a> {
 
     /// Adds an annotation to a portion of the query string.  The given position will be
     /// highlighted with the accompanying label.
-    pub fn with_annotation_range<S: ToString>(
+    pub fn with_code_range<S: ToString>(
         mut self,
         start_pos: QueryPosition,
         end_pos: QueryPosition,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,212 @@
+use crate::lang::{query, Positioned, Query, QueryPosition, Span};
+use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use nom::types::CompleteStr;
+use nom::ErrorKind;
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use std::convert::From;
+
+/// Container for the query string that can be used to parse and report errors.
+pub struct QueryContainer {
+    query: String,
+    reporter: Box<ErrorReporter>,
+}
+
+/// Common syntax errors.
+#[derive(PartialEq, Debug, FromPrimitive, Fail)]
+pub enum SyntaxErrors {
+    #[fail(display = "")]
+    DelimiterStart,
+    #[fail(display = "unterminated double quoted string")]
+    UnterminatedString,
+    #[fail(display = "expecting close parentheses")]
+    MissingParen,
+}
+
+/// Trait that can be used to report errors by the parser and other layers.
+pub trait ErrorBuilder {
+    /// Create a SnippetBuilder for the given error
+    fn report_error_for<E: ToString>(&self, error: E) -> SnippetBuilder;
+}
+
+impl QueryContainer {
+    pub fn new(query: String, reporter: Box<ErrorReporter>) -> QueryContainer {
+        QueryContainer { query, reporter }
+    }
+
+    /// Parse the contained query string.
+    pub fn parse(&self) -> Result<Query, QueryPosition> {
+        let parse_result = query(Span::new(CompleteStr(&self.query)));
+
+        match parse_result {
+            Err(nom::Err::Failure(nom::Context::List(ref list))) => {
+                // Check for an error from a delimited!() parser.  The error list will contain
+                // the location of the start as the last item and the location of the end as the
+                // penultimate item.
+                let last_chunk = list.rchunks_exact(2).next().map(|p| (&p[0], &p[1]));
+
+                match last_chunk {
+                    Some((
+                        (ref end_span, ErrorKind::Custom(ref delim_error)),
+                        (ref start_span, ErrorKind::Custom(SyntaxErrors::DelimiterStart)),
+                    )) => {
+                        self.report_error_for(delim_error)
+                            .with_annotation_range((*start_span).into(), (*end_span).into(), "")
+                            .with_resolutions(delim_error.to_resolution())
+                            .send_report();
+                    }
+                    _ => self.report_error_for(format!("{:?}", list)).send_report(),
+                }
+            }
+            Err(nom::Err::Error(nom::Context::Code(span, _))) => {
+                self.report_error_for("Unexpected input")
+                    .with_annotation_range(span.into(), QueryPosition(self.query.len()), "")
+                    .send_report();
+            }
+            _ => (),
+        }
+        // Return the parsed value or the last position of valid syntax
+        parse_result.map(|x| x.1).map_err(|e| match e {
+            nom::Err::Incomplete(_) => QueryPosition(0),
+            nom::Err::Error(context) | nom::Err::Failure(context) => match context {
+                nom::Context::Code(span, _) => span.into(),
+                nom::Context::List(list) => list.first().unwrap().0.into(),
+            },
+        })
+    }
+}
+
+impl ErrorBuilder for QueryContainer {
+    /// Create a SnippetBuilder for the given error
+    fn report_error_for<E: ToString>(&self, error: E) -> SnippetBuilder {
+        SnippetBuilder {
+            query: self,
+            data: SnippetData {
+                error: error.to_string(),
+                source: self.query.to_string(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl SyntaxErrors {
+    pub fn to_resolution(&self) -> Vec<String> {
+        match self {
+            SyntaxErrors::DelimiterStart => Vec::new(),
+            SyntaxErrors::UnterminatedString => {
+                vec!["Insert a double quote to terminate this string".to_string()]
+            }
+            SyntaxErrors::MissingParen => {
+                vec!["Insert a right parenthesis to close this expression".to_string()]
+            }
+        }
+    }
+}
+
+/// Converts the ordinal from the nom error object back into a SyntaxError.
+impl From<u32> for SyntaxErrors {
+    fn from(ord: u32) -> Self {
+        // The FromPrimitive trait derived for this enum allows from_u32() to work.
+        SyntaxErrors::from_u32(ord).unwrap()
+    }
+}
+
+impl From<SyntaxErrors> for ErrorKind {
+    fn from(e: SyntaxErrors) -> Self {
+        ErrorKind::Custom(e as u32)
+    }
+}
+
+/// Callback for handling error Snippets.
+pub trait ErrorReporter {
+    fn handle_error(&self, _snippet: Snippet) {}
+}
+
+/// Container for data that will be used to construct a Snippet
+#[derive(Default)]
+pub struct SnippetData {
+    error: String,
+    source: String,
+    annotations: Vec<((usize, usize), String)>,
+    resolution: Vec<String>,
+}
+
+pub struct SnippetBuilder<'a> {
+    query: &'a QueryContainer,
+    data: SnippetData,
+}
+
+impl<'a> SnippetBuilder<'a> {
+    /// Adds an annotation to a portion of the query string.  The given position will be
+    /// highlighted with the accompanying label.
+    pub fn with_annotation<T, S: ToString>(mut self, pos: &Positioned<T>, label: S) -> Self {
+        self.data
+            .annotations
+            .push(((pos.start_pos.0, pos.end_pos.0), label.to_string()));
+        self
+    }
+
+    /// Adds an annotation to a portion of the query string.  The given position will be
+    /// highlighted with the accompanying label.
+    pub fn with_annotation_range<S: ToString>(
+        mut self,
+        start_pos: QueryPosition,
+        end_pos: QueryPosition,
+        label: S,
+    ) -> Self {
+        self.data
+            .annotations
+            .push(((start_pos.0, end_pos.0), label.to_string()));
+        self
+    }
+
+    /// Add a message to help the user resolve the error.
+    pub fn with_resolution<T: ToString>(mut self, resolution: T) -> Self {
+        self.data.resolution.push(resolution.to_string());
+        self
+    }
+
+    /// Add a message to help the user resolve the error.
+    pub fn with_resolutions<T: IntoIterator<Item = String>>(mut self, resolutions: T) -> Self {
+        self.data.resolution.extend(resolutions.into_iter());
+        self
+    }
+
+    /// Build and send the Snippet to the ErrorReporter in the QueryContainer.
+    pub fn send_report(mut self) {
+        self.query.reporter.handle_error(Snippet {
+            title: Some(Annotation {
+                label: Some(self.data.error),
+                id: None,
+                annotation_type: AnnotationType::Error,
+            }),
+            slices: vec![Slice {
+                source: self.data.source,
+                line_start: 1,
+                origin: None,
+                fold: false,
+                annotations: self
+                    .data
+                    .annotations
+                    .drain(..)
+                    .map(move |anno| SourceAnnotation {
+                        range: anno.0,
+                        label: anno.1,
+                        annotation_type: AnnotationType::Error,
+                    })
+                    .collect(),
+            }],
+            footer: self
+                .data
+                .resolution
+                .iter()
+                .map(|res| Annotation {
+                    label: Some(res.to_string()),
+                    id: None,
+                    annotation_type: AnnotationType::Help,
+                })
+                .collect(),
+        });
+    }
+}

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,11 +1,10 @@
 use crate::data;
-use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
+use crate::errors::SyntaxErrors;
 use nom;
 use nom::types::CompleteStr;
 use nom::*;
 use nom::{digit1, double, is_alphabetic, is_alphanumeric, is_digit, multispace};
 use nom_locate::LocatedSpan;
-use num_traits::FromPrimitive;
 use std::convert::From;
 use std::str;
 
@@ -53,192 +52,6 @@ pub struct Positioned<T> {
 impl<T> Positioned<T> {
     pub fn into(&self) -> &T {
         &self.value
-    }
-}
-
-/// Common syntax errors.
-#[derive(PartialEq, Debug, FromPrimitive, Fail)]
-pub enum SyntaxErrors {
-    #[fail(display = "")]
-    DelimiterStart,
-    #[fail(display = "unterminated double quote string")]
-    UnterminatedString,
-    #[fail(display = "expecting close parentheses")]
-    MissingParen,
-}
-
-impl SyntaxErrors {
-    fn to_resolution(&self) -> &'static str {
-        match self {
-            SyntaxErrors::DelimiterStart => "",
-            SyntaxErrors::UnterminatedString => "Insert a double quote to terminate this string",
-            SyntaxErrors::MissingParen => "Insert a right parenthesis to close this expression",
-        }
-    }
-}
-
-/// Converts the ordinal from the nom error object back into a SyntaxError.
-impl From<u32> for SyntaxErrors {
-    fn from(ord: u32) -> Self {
-        SyntaxErrors::from_u32(ord).unwrap()
-    }
-}
-
-impl From<SyntaxErrors> for ErrorKind {
-    fn from(e: SyntaxErrors) -> Self {
-        ErrorKind::Custom(e as u32)
-    }
-}
-
-/// Callback for handling error Snippets.
-pub trait ErrorReporter {
-    fn handle_error(&self, _snippet: Snippet) {}
-}
-
-/// Container for the query string that can be used to parse and report errors.
-pub struct QueryContainer {
-    query: String,
-    reporter: Box<ErrorReporter>,
-}
-
-impl QueryContainer {
-    pub fn new(query: String, reporter: Box<ErrorReporter>) -> QueryContainer {
-        QueryContainer { query, reporter }
-    }
-
-    /// Create a SnippetBuilder for the given error
-    pub fn report_error_for<E: ToString>(&self, error: E) -> SnippetBuilder {
-        SnippetBuilder {
-            query: self,
-            data: SnippetData {
-                error: error.to_string(),
-                source: self.query.to_string(),
-                ..Default::default()
-            },
-        }
-    }
-
-    /// Parse the contained query string.
-    pub fn parse(&self) -> Result<Query, QueryPosition> {
-        let parse_result = query(Span::new(CompleteStr(&self.query)));
-
-        match parse_result {
-            Err(nom::Err::Failure(nom::Context::List(ref list))) => {
-                // Check for an error from a delimited!() parser.  The error list will contain
-                // the location of the start as the last item and the location of the end as the
-                // penultimate item.
-                let last_chunk = list.rchunks_exact(2).next().map(|p| (&p[0], &p[1]));
-
-                match last_chunk {
-                    Some((
-                        (ref end_span, ErrorKind::Custom(ref delim_error)),
-                        (ref start_span, ErrorKind::Custom(SyntaxErrors::DelimiterStart)),
-                    )) => {
-                        self.report_error_for(delim_error)
-                            .with_annotation_range((*start_span).into(), (*end_span).into(), "")
-                            .with_resolution(delim_error.to_resolution())
-                            .send_report();
-                    }
-                    _ => self.report_error_for(format!("{:?}", list)).send_report(),
-                }
-            }
-            Err(nom::Err::Error(nom::Context::Code(span, _))) => {
-                self.report_error_for("Unexpected input")
-                    .with_annotation_range(span.into(), QueryPosition(self.query.len()), "")
-                    .send_report();
-            }
-            _ => (),
-        }
-        // Return the parsed value or the last position of valid syntax
-        parse_result.map(|x| x.1).map_err(|e| match e {
-            nom::Err::Incomplete(_) => QueryPosition(0),
-            nom::Err::Error(context) | nom::Err::Failure(context) => match context {
-                nom::Context::Code(span, _) => span.into(),
-                nom::Context::List(list) => list.first().unwrap().0.into(),
-            },
-        })
-    }
-}
-
-/// Container for data that will be used to construct a Snippet
-#[derive(Default)]
-pub struct SnippetData {
-    error: String,
-    source: String,
-    annotations: Vec<((usize, usize), String)>,
-    resolution: Vec<String>,
-}
-
-pub struct SnippetBuilder<'a> {
-    query: &'a QueryContainer,
-    data: SnippetData,
-}
-
-impl<'a> SnippetBuilder<'a> {
-    /// Adds an annotation to a portion of the query string.  The given position will be
-    /// highlighted with the accompanying label.
-    pub fn with_annotation<T, S: ToString>(mut self, pos: &Positioned<T>, label: S) -> Self {
-        self.data
-            .annotations
-            .push(((pos.start_pos.0, pos.end_pos.0), label.to_string()));
-        self
-    }
-
-    /// Adds an annotation to a portion of the query string.  The given position will be
-    /// highlighted with the accompanying label.
-    pub fn with_annotation_range<S: ToString>(
-        mut self,
-        start_pos: QueryPosition,
-        end_pos: QueryPosition,
-        label: S,
-    ) -> Self {
-        self.data
-            .annotations
-            .push(((start_pos.0, end_pos.0), label.to_string()));
-        self
-    }
-
-    /// Add a message to help the user resolve the error.
-    pub fn with_resolution<T: ToString>(mut self, resolution: T) -> Self {
-        self.data.resolution.push(resolution.to_string());
-        self
-    }
-
-    /// Build and send the Snippet to the ErrorReporter in the QueryContainer.
-    pub fn send_report(mut self) {
-        self.query.reporter.handle_error(Snippet {
-            title: Some(Annotation {
-                label: Some(self.data.error),
-                id: None,
-                annotation_type: AnnotationType::Error,
-            }),
-            slices: vec![Slice {
-                source: self.data.source,
-                line_start: 1,
-                origin: None,
-                fold: false,
-                annotations: self
-                    .data
-                    .annotations
-                    .drain(..)
-                    .map(move |anno| SourceAnnotation {
-                        range: anno.0,
-                        label: anno.1,
-                        annotation_type: AnnotationType::Error,
-                    })
-                    .collect(),
-            }],
-            footer: self
-                .data
-                .resolution
-                .iter()
-                .map(|res| Annotation {
-                    label: Some(res.to_string()),
-                    id: None,
-                    annotation_type: AnnotationType::Help,
-                })
-                .collect(),
-        });
     }
 }
 
@@ -694,7 +507,7 @@ named!(filter<Span, Vec<Keyword>>, map!(
     }
 ));
 
-named!(query<Span, Query, SyntaxErrors>, fix_error!(SyntaxErrors, exact!(ws!(do_parse!(
+named!(pub query<Span, Query, SyntaxErrors>, fix_error!(SyntaxErrors, exact!(ws!(do_parse!(
     filter: filter >>
     operators: opt!(preceded!(tag!("|"), ws!(separated_nonempty_list!(tag!("|"), operator)))) >>
     (Query{

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,9 +1,246 @@
 use crate::data;
+use annotate_snippets::snippet::{Annotation, AnnotationType, Slice, Snippet, SourceAnnotation};
 use nom;
 use nom::types::CompleteStr;
 use nom::*;
 use nom::{digit1, double, is_alphabetic, is_alphanumeric, is_digit, multispace};
+use nom_locate::LocatedSpan;
+use num_traits::FromPrimitive;
+use std::convert::From;
 use std::str;
+
+/// Wraps the result of the child parser in a Positioned and sets the start_pos and end_pos
+/// accordingly.
+macro_rules! with_pos {
+  ($i:expr, $submac:ident!( $($args:tt)* )) => ({
+      let start_pos: QueryPosition = $i.into();
+      match $submac!($i, $($args)*) {
+          Ok((i,o)) => Ok((i, Positioned {
+              start_pos,
+              value: o,
+              end_pos: i.into(),
+          })),
+          Err(e) => Err(e),
+      }
+  });
+  ($i:expr, $f:expr) => (
+    with_pos!($i, call!($f));
+  );
+}
+
+/// Type used to track the current fragment being parsed and its location in the original input.
+pub type Span<'a> = LocatedSpan<CompleteStr<'a>>;
+
+/// Container for the position of some syntax in the input string.  This is similar to the Span,
+/// but it only contains the offset.
+#[derive(Debug, PartialEq, Clone)]
+pub struct QueryPosition(pub usize);
+
+impl<'a> From<Span<'a>> for QueryPosition {
+    fn from(located_span: Span<'a>) -> Self {
+        QueryPosition(located_span.offset)
+    }
+}
+
+/// Container for values from the query that records the location in the query string.
+#[derive(Debug, PartialEq, Clone)]
+pub struct Positioned<T> {
+    pub start_pos: QueryPosition,
+    pub end_pos: QueryPosition,
+    pub value: T,
+}
+
+impl<T> Positioned<T> {
+    pub fn into(&self) -> &T {
+        &self.value
+    }
+}
+
+/// Common syntax errors.
+#[derive(PartialEq, Debug, FromPrimitive, Fail)]
+pub enum SyntaxErrors {
+    #[fail(display = "")]
+    DelimiterStart,
+    #[fail(display = "unterminated double quote string")]
+    UnterminatedString,
+    #[fail(display = "expecting close parentheses")]
+    MissingParen,
+}
+
+impl SyntaxErrors {
+    fn to_resolution(&self) -> &'static str {
+        match self {
+            SyntaxErrors::DelimiterStart => "",
+            SyntaxErrors::UnterminatedString => "Insert a double quote to terminate this string",
+            SyntaxErrors::MissingParen => "Insert a right parenthesis to close this expression",
+        }
+    }
+}
+
+/// Converts the ordinal from the nom error object back into a SyntaxError.
+impl From<u32> for SyntaxErrors {
+    fn from(ord: u32) -> Self {
+        SyntaxErrors::from_u32(ord).unwrap()
+    }
+}
+
+impl From<SyntaxErrors> for ErrorKind {
+    fn from(e: SyntaxErrors) -> Self {
+        ErrorKind::Custom(e as u32)
+    }
+}
+
+/// Callback for handling error Snippets.
+pub trait ErrorReporter {
+    fn handle_error(&self, _snippet: Snippet) {}
+}
+
+/// Container for the query string that can be used to parse and report errors.
+pub struct QueryContainer {
+    query: String,
+    reporter: Box<ErrorReporter>,
+}
+
+impl QueryContainer {
+    pub fn new(query: String, reporter: Box<ErrorReporter>) -> QueryContainer {
+        QueryContainer { query, reporter }
+    }
+
+    /// Create a SnippetBuilder for the given error
+    pub fn report_error_for<E: ToString>(&self, error: E) -> SnippetBuilder {
+        SnippetBuilder {
+            query: self,
+            data: SnippetData {
+                error: error.to_string(),
+                source: self.query.to_string(),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Parse the contained query string.
+    pub fn parse(&self) -> Result<Query, QueryPosition> {
+        let parse_result = query(Span::new(CompleteStr(&self.query)));
+
+        match parse_result {
+            Err(nom::Err::Failure(nom::Context::List(ref list))) => {
+                // Check for an error from a delimited!() parser.  The error list will contain
+                // the location of the start as the last item and the location of the end as the
+                // penultimate item.
+                let last_chunk = list.rchunks_exact(2).next().map(|p| (&p[0], &p[1]));
+
+                match last_chunk {
+                    Some((
+                        (ref end_span, ErrorKind::Custom(ref delim_error)),
+                        (ref start_span, ErrorKind::Custom(SyntaxErrors::DelimiterStart)),
+                    )) => {
+                        self.report_error_for(delim_error)
+                            .with_annotation_range((*start_span).into(), (*end_span).into(), "")
+                            .with_resolution(delim_error.to_resolution())
+                            .send_report();
+                    }
+                    _ => self.report_error_for(format!("{:?}", list)).send_report(),
+                }
+            }
+            Err(nom::Err::Error(nom::Context::Code(span, _))) => {
+                self.report_error_for("Unexpected input")
+                    .with_annotation_range(span.into(), QueryPosition(self.query.len()), "")
+                    .send_report();
+            }
+            _ => (),
+        }
+        // Return the parsed value or the last position of valid syntax
+        parse_result.map(|x| x.1).map_err(|e| match e {
+            nom::Err::Incomplete(_) => QueryPosition(0),
+            nom::Err::Error(context) | nom::Err::Failure(context) => match context {
+                nom::Context::Code(span, _) => span.into(),
+                nom::Context::List(list) => list.first().unwrap().0.into(),
+            },
+        })
+    }
+}
+
+/// Container for data that will be used to construct a Snippet
+#[derive(Default)]
+pub struct SnippetData {
+    error: String,
+    source: String,
+    annotations: Vec<((usize, usize), String)>,
+    resolution: Vec<String>,
+}
+
+pub struct SnippetBuilder<'a> {
+    query: &'a QueryContainer,
+    data: SnippetData,
+}
+
+impl<'a> SnippetBuilder<'a> {
+    /// Adds an annotation to a portion of the query string.  The given position will be
+    /// highlighted with the accompanying label.
+    pub fn with_annotation<T, S: ToString>(mut self, pos: &Positioned<T>, label: S) -> Self {
+        self.data
+            .annotations
+            .push(((pos.start_pos.0, pos.end_pos.0), label.to_string()));
+        self
+    }
+
+    /// Adds an annotation to a portion of the query string.  The given position will be
+    /// highlighted with the accompanying label.
+    pub fn with_annotation_range<S: ToString>(
+        mut self,
+        start_pos: QueryPosition,
+        end_pos: QueryPosition,
+        label: S,
+    ) -> Self {
+        self.data
+            .annotations
+            .push(((start_pos.0, end_pos.0), label.to_string()));
+        self
+    }
+
+    /// Add a message to help the user resolve the error.
+    pub fn with_resolution<T: ToString>(mut self, resolution: T) -> Self {
+        self.data.resolution.push(resolution.to_string());
+        self
+    }
+
+    /// Build and send the Snippet to the ErrorReporter in the QueryContainer.
+    pub fn send_report(mut self) {
+        self.query.reporter.handle_error(Snippet {
+            title: Some(Annotation {
+                label: Some(self.data.error),
+                id: None,
+                annotation_type: AnnotationType::Error,
+            }),
+            slices: vec![Slice {
+                source: self.data.source,
+                line_start: 1,
+                origin: None,
+                fold: false,
+                annotations: self
+                    .data
+                    .annotations
+                    .drain(..)
+                    .map(move |anno| SourceAnnotation {
+                        range: anno.0,
+                        label: anno.1,
+                        annotation_type: AnnotationType::Error,
+                    })
+                    .collect(),
+            }],
+            footer: self
+                .data
+                .resolution
+                .iter()
+                .map(|res| Annotation {
+                    label: Some(res.to_string()),
+                    id: None,
+                    annotation_type: AnnotationType::Help,
+                })
+                .collect(),
+        });
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ComparisonOp {
@@ -104,7 +341,7 @@ pub enum InlineOperator {
     Limit {
         /// The count for the limit is pretty loosely typed at this point, the next phase will
         /// check the value to see if it's sane or provide a default if no number was given.
-        count: Option<f64>,
+        count: Option<Positioned<f64>>,
     },
     Total {
         input_column: Expr,
@@ -139,7 +376,7 @@ pub enum AggregateFunction {
         column: Expr,
     },
     CountDistinct {
-        column: Expr,
+        column: Option<Positioned<Vec<Expr>>>,
     },
 }
 
@@ -147,7 +384,7 @@ pub enum AggregateFunction {
 pub struct MultiAggregateOperator {
     pub key_cols: Vec<Expr>,
     pub key_col_headers: Vec<String>,
-    pub aggregate_functions: Vec<(String, AggregateFunction)>,
+    pub aggregate_functions: Vec<(String, Positioned<AggregateFunction>)>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -187,33 +424,36 @@ fn not_escape(c: char) -> bool {
     c != '\\' && c != '\"'
 }
 
-named!(value<CompleteStr, data::Value>, ws!(
+named!(value<Span, data::Value>, ws!(
     alt!(
         map!(quoted_string, |s|data::Value::Str(s.to_string()))
-        | map!(digit1, |s|data::Value::from_string(s.0))
+        | map!(digit1, |s|data::Value::from_string(s.fragment.0))
     )
 ));
-named!(ident<CompleteStr, String>, do_parse!(
+named!(ident<Span, String>, do_parse!(
     start: take_while1!(starts_ident) >>
     rest: take_while!(is_ident) >>
-    (start.0.to_owned() + rest.0)
+    (start.fragment.0.to_owned() + rest.fragment.0)
 ));
 
-named!(e_ident<CompleteStr, Expr>,
+named!(e_ident<Span, Expr>,
     ws!(alt!(
       map!(ident, |col|Expr::Column(col.to_owned()))
     | map!(value, Expr::Value)
       //expr
-    |  ws!(delimited!( tag_s!("("), expr, tag_s!(")") ))
+    | ws!(add_return_error!(SyntaxErrors::DelimiterStart.into(), delimited!(
+          tag!("("),
+          expr,
+          return_error!(SyntaxErrors::MissingParen.into(), tag!(")")))))
 )));
 
-named!(keyword<CompleteStr, String>, do_parse!(
+named!(keyword<Span, String>, do_parse!(
     start: take_while1!(is_keyword) >>
     rest: take_while!(is_keyword) >>
-    (start.0.to_owned() + rest.0)
+    (start.fragment.0.to_owned() + rest.fragment.0)
 ));
 
-named!(comp_op<CompleteStr, ComparisonOp>, ws!(alt!(
+named!(comp_op<Span, ComparisonOp>, ws!(alt!(
     map!(tag!("=="), |_|ComparisonOp::Eq)
     | map!(tag!("<="), |_|ComparisonOp::Lte)
     | map!(tag!(">="), |_|ComparisonOp::Gte)
@@ -222,7 +462,7 @@ named!(comp_op<CompleteStr, ComparisonOp>, ws!(alt!(
     | map!(tag!("<"), |_|ComparisonOp::Lt)
 )));
 
-named!(expr<CompleteStr, Expr>, ws!(alt!(
+named!(expr<Span, Expr>, ws!(alt!(
     do_parse!(
         l: e_ident >>
         comp: comp_op >>
@@ -232,25 +472,27 @@ named!(expr<CompleteStr, Expr>, ws!(alt!(
     | e_ident
 )));
 
-named!(json<CompleteStr, InlineOperator>, ws!(do_parse!(
+named!(json<Span, InlineOperator>, ws!(do_parse!(
     tag!("json") >>
     from_column_opt: opt!(ws!(preceded!(tag!("from"), ident))) >>
     (InlineOperator::Json { input_column: from_column_opt.map(|s|s.to_string()) })
 )));
 
-named!(whre<CompleteStr, InlineOperator>, ws!(do_parse!(
+named!(whre<Span, InlineOperator>, ws!(do_parse!(
     tag!("where") >>
     ex: expr >>
     (InlineOperator::Where { expr: ex })
 )));
 
-named!(limit<CompleteStr, InlineOperator>, ws!(do_parse!(
+named!(limit<Span, InlineOperator>, ws!(do_parse!(
     tag!("limit") >>
-    count: opt!(double) >>
-    (InlineOperator::Limit{ count })
+    count: opt!(with_pos!(double)) >>
+    (InlineOperator::Limit{
+        count
+    })
 )));
 
-named!(total<CompleteStr, InlineOperator>, ws!(do_parse!(
+named!(total<Span, InlineOperator>, ws!(do_parse!(
     tag!("total") >>
     input_column: delimited!(tag!("("), expr, tag!(")")) >>
     rename_opt: opt!(ws!(preceded!(tag!("as"), ident))) >>
@@ -260,30 +502,31 @@ named!(total<CompleteStr, InlineOperator>, ws!(do_parse!(
             rename_opt.map(|s|s.to_string()).unwrap_or_else(||"_total".to_string()),
 }))));
 
-named!(quoted_string <CompleteStr, &str>, delimited!(
-    tag!("\""), 
-    map!(escaped!(take_while1!(not_escape), '\\', one_of!("\"n\\")), |ref s|s.0),
-    tag!("\"") 
-));
+named!(quoted_string <Span, &str>,  add_return_error!(
+    SyntaxErrors::DelimiterStart.into(), delimited!(
+        tag!("\""),
+        map!(escaped!(take_while1!(not_escape), '\\', anychar), |ref s|s.fragment.0),
+        return_error!(SyntaxErrors::UnterminatedString.into(), tag!("\""))
+)));
 
-named!(var_list<CompleteStr, Vec<String> >, ws!(separated_nonempty_list!(
+named!(var_list<Span, Vec<String> >, ws!(separated_nonempty_list!(
     tag!(","), ws!(ident)
 )));
 
-named!(sourced_expr_list<CompleteStr, Vec<(String, Expr)> >, ws!(separated_nonempty_list!(
+named!(sourced_expr_list<Span, Vec<(String, Expr)> >, ws!(separated_nonempty_list!(
     tag!(","), ws!(sourced_expr)
 )));
 
-named!(sourced_expr<CompleteStr, (String, Expr)>, ws!(
+named!(sourced_expr<Span, (String, Expr)>, ws!(
     do_parse!(
         ex: recognize!(expr) >>
         (
-            (ex.0.trim().to_string(), expr(ex).unwrap().1)
+            (ex.fragment.0.trim().to_string(), expr(ex).unwrap().1)
         )
 )));
 
 // parse "blah * ... *" [from other_field] as x, y
-named!(parse<CompleteStr, InlineOperator>, ws!(do_parse!(
+named!(parse<Span, InlineOperator>, ws!(do_parse!(
     tag!("parse") >>
     pattern: quoted_string >>
     from_column_opt: opt!(ws!(preceded!(tag!("from"), expr))) >>
@@ -296,7 +539,7 @@ named!(parse<CompleteStr, InlineOperator>, ws!(do_parse!(
         } )
 )));
 
-named!(fields_mode<CompleteStr, FieldMode>, alt!(
+named!(fields_mode<Span, FieldMode>, alt!(
     map!(
         alt!(tag!("+") | tag!("only") | tag!("include")),
         |_|FieldMode::Only
@@ -307,7 +550,7 @@ named!(fields_mode<CompleteStr, FieldMode>, alt!(
     )
 ));
 
-named!(fields<CompleteStr, InlineOperator>, ws!(do_parse!(
+named!(fields<Span, InlineOperator>, ws!(do_parse!(
     tag!("fields") >>
     mode: opt!(fields_mode) >>
     fields: var_list >>
@@ -319,60 +562,69 @@ named!(fields<CompleteStr, InlineOperator>, ws!(do_parse!(
     )
 )));
 
-named!(count<CompleteStr, AggregateFunction>, map!(tag!("count"), |_s|AggregateFunction::Count{}));
+named!(arg_list<Span, Positioned<Vec<Expr>>>, add_return_error!(
+    SyntaxErrors::DelimiterStart.into(), with_pos!(delimited!(
+        tag!("("),
+        ws!(separated_list!(tag!(","), ws!(expr))),
+        return_error!(SyntaxErrors::MissingParen.into(), tag!(")"))))
+));
 
-named!(average<CompleteStr, AggregateFunction>, ws!(do_parse!(
+named!(count<Span, Positioned<AggregateFunction>>, with_pos!(map!(tag!("count"),
+    |_s|AggregateFunction::Count{}))
+);
+
+named!(average<Span, Positioned<AggregateFunction>>, ws!(with_pos!(do_parse!(
     alt!(tag!("avg") | tag!("average")) >>
     column: delimited!(tag!("("), expr ,tag!(")")) >>
     (AggregateFunction::Average{column})
-)));
+))));
 
-named!(count_distinct<CompleteStr, AggregateFunction>, ws!(do_parse!(
+named!(count_distinct<Span, Positioned<AggregateFunction>>, ws!(with_pos!(do_parse!(
     tag!("count_distinct") >>
-    column: delimited!(tag!("("), expr,tag!(")")) >>
-    (AggregateFunction::CountDistinct{column})
-)));
+    column: opt!(arg_list) >>
+    (AggregateFunction::CountDistinct{ column })
+))));
 
-named!(sum<CompleteStr, AggregateFunction>, ws!(do_parse!(
+named!(sum<Span, Positioned<AggregateFunction>>, ws!(with_pos!(do_parse!(
     tag!("sum") >>
     column: delimited!(tag!("("), expr,tag!(")")) >>
     (AggregateFunction::Sum{column})
-)));
+))));
 
 fn is_digit_char(digit: char) -> bool {
     is_digit(digit as u8)
 }
 
-named!(p_nn<CompleteStr, AggregateFunction>, ws!(
-    do_parse!(
+named!(p_nn<Span, Positioned<AggregateFunction>>, ws!(
+    with_pos!(do_parse!(
         alt!(tag!("pct") | tag!("percentile") | tag!("p")) >>
         pct: take_while_m_n!(2, 2, is_digit_char) >>
         column: delimited!(tag!("("), expr,tag!(")")) >>
         (AggregateFunction::Percentile{
             column,
-            percentile: (".".to_owned() + pct.0).parse::<f64>().unwrap(),
-            percentile_str: pct.0.to_string()
+            percentile: (".".to_owned() + pct.fragment.0).parse::<f64>().unwrap(),
+            percentile_str: pct.fragment.0.to_string()
         })
-    )
+    ))
 ));
 
-named!(inline_operator<CompleteStr, Operator>,
+named!(inline_operator<Span, Operator>,
    map!(alt!(parse | json | fields | whre | limit | total), Operator::Inline)
 );
-named!(aggregate_function<CompleteStr, AggregateFunction>, alt!(
+named!(aggregate_function<Span, Positioned<AggregateFunction>>, alt!(
     count_distinct |
     count |
     average |
     sum |
     p_nn));
 
-named!(operator<CompleteStr, Operator>, alt!(inline_operator | sort | multi_aggregate_operator));
+named!(operator<Span, Operator>, alt!(inline_operator | sort | multi_aggregate_operator));
 
 // count by x,y
 // avg(foo) by x
 
-fn default_output(func: &AggregateFunction) -> String {
-    match *func {
+fn default_output(func: &Positioned<AggregateFunction>) -> String {
+    match func.into() {
         AggregateFunction::Count { .. } => "_count".to_string(),
         AggregateFunction::Sum { .. } => "_sum".to_string(),
         AggregateFunction::Average { .. } => "_average".to_string(),
@@ -383,7 +635,7 @@ fn default_output(func: &AggregateFunction) -> String {
     }
 }
 
-named!(complete_agg_function<CompleteStr, (String, AggregateFunction)>, ws!(do_parse!(
+named!(complete_agg_function<Span, (String, Positioned<AggregateFunction>)>, ws!(do_parse!(
         agg_function: aggregate_function >>
         rename_opt: opt!(ws!(preceded!(tag!("as"), ident))) >>
         (
@@ -393,7 +645,7 @@ named!(complete_agg_function<CompleteStr, (String, AggregateFunction)>, ws!(do_p
     ))
 );
 
-named!(multi_aggregate_operator<CompleteStr, Operator>, ws!(do_parse!(
+named!(multi_aggregate_operator<Span, Operator>, ws!(do_parse!(
     agg_functions: ws!(separated_nonempty_list!(tag!(","), complete_agg_function)) >>
     key_cols_opt: opt!(preceded!(tag!("by"), sourced_expr_list)) >>
     (Operator::MultiAggregate(MultiAggregateOperator {
@@ -407,7 +659,7 @@ named!(multi_aggregate_operator<CompleteStr, Operator>, ws!(do_parse!(
      })))
 ));
 
-named!(sort_mode<CompleteStr, SortMode>, alt!(
+named!(sort_mode<Span, SortMode>, alt!(
     map!(
         alt!(tag!("asc") | tag!("ascending")),
         |_|SortMode::Ascending
@@ -418,7 +670,7 @@ named!(sort_mode<CompleteStr, SortMode>, alt!(
     )
 ));
 
-named!(sort<CompleteStr, Operator>, ws!(do_parse!(
+named!(sort<Span, Operator>, ws!(do_parse!(
     tag!("sort") >>
     key_cols_opt: opt!(preceded!(opt!(tag!("by")), var_list)) >>
     dir: opt!(sort_mode) >>
@@ -428,12 +680,12 @@ named!(sort<CompleteStr, Operator>, ws!(do_parse!(
      })))
 ));
 
-named!(filter_cond<CompleteStr, Keyword>, alt!(
+named!(filter_cond<Span, Keyword>, alt!(
     map!(quoted_string, |s| Keyword::new_exact(s.to_string())) |
     map!(keyword, |s| Keyword::new_wildcard(s.trim_matches('*').to_string()))
 ));
 
-named!(filter<CompleteStr, Vec<Keyword>>, map!(
+named!(filter<Span, Vec<Keyword>>, map!(
     separated_nonempty_list!(multispace, filter_cond),
     // An empty keyword would match everything, so there's no reason to
     |mut v| {
@@ -442,20 +694,14 @@ named!(filter<CompleteStr, Vec<Keyword>>, map!(
     }
 ));
 
-named!(query<CompleteStr, Query>, ws!(do_parse!(
+named!(query<Span, Query, SyntaxErrors>, fix_error!(SyntaxErrors, exact!(ws!(do_parse!(
     filter: filter >>
     operators: opt!(preceded!(tag!("|"), ws!(separated_nonempty_list!(tag!("|"), operator)))) >>
-    eof!() >>
     (Query{
         search: filter,
         operators: operators.unwrap_or_default()
-    })
-)));
-
-pub fn parse_query(query_str: &str) -> Result<Query, nom::Err<CompleteStr, u32>> {
-    let parse_result = query(CompleteStr(query_str));
-    parse_result.map(|x| x.1)
-}
+    }))
+))));
 
 #[cfg(test)]
 mod tests {
@@ -463,26 +709,32 @@ mod tests {
 
     macro_rules! expect {
         ($f:expr, $inp:expr, $res:expr) => {{
-            let parse_result = $f(CompleteStr($inp));
-            let actual_result = parse_result.map(|res| res.1);
-            assert_eq!(actual_result, $res);
-            let parse_result = $f(CompleteStr($inp));
-            let _ = parse_result.map(|(leftover, _res)| {
-                assert_eq!(leftover, CompleteStr(""));
-            });
+            let parse_result = $f(Span::new(CompleteStr($inp)));
+            match parse_result {
+                Ok((
+                    LocatedSpan {
+                        fragment: leftover, ..
+                    },
+                    actual_result,
+                )) => {
+                    assert_eq!(actual_result, $res);
+                    assert_eq!(leftover, CompleteStr(""));
+                }
+                Err(e) => panic!(format!("{:?}", e)),
+            }
         }};
     }
 
     #[test]
     fn parse_keyword_string() {
-        expect!(keyword, "abc", Ok("abc".to_string()));
-        expect!(keyword, "one-two-three", Ok("one-two-three".to_string()));
+        expect!(keyword, "abc", "abc".to_string());
+        expect!(keyword, "one-two-three", "one-two-three".to_string());
     }
 
     #[test]
     fn parse_quoted_string() {
-        expect!(quoted_string, "\"hello\"", Ok("hello"));
-        expect!(quoted_string, r#""test = [*=*] * ""#, Ok("test = [*=*] * "))
+        expect!(quoted_string, "\"hello\"", "hello");
+        expect!(quoted_string, r#""test = [*=*] * ""#, "test = [*=*] * ");
     }
 
     #[test]
@@ -490,11 +742,11 @@ mod tests {
         expect!(
             expr,
             "a == b",
-            Ok(Expr::Binary {
+            Expr::Binary {
                 op: BinaryOp::Comparison(ComparisonOp::Eq),
                 left: Box::new(Expr::Column("a".to_string())),
                 right: Box::new(Expr::Column("b".to_string())),
-            })
+            }
         );
     }
 
@@ -503,24 +755,24 @@ mod tests {
         expect!(
             expr,
             "a <= \"b\"",
-            Ok(Expr::Binary {
+            Expr::Binary {
                 op: BinaryOp::Comparison(ComparisonOp::Lte),
                 left: Box::new(Expr::Column("a".to_string())),
                 right: Box::new(Expr::Value(data::Value::Str("b".to_string()))),
-            })
+            }
         );
     }
 
     #[test]
     fn parse_expr_ident() {
-        expect!(expr, "foo", Ok(Expr::Column("foo".to_string())));
+        expect!(expr, "foo", Expr::Column("foo".to_string()));
     }
 
     #[test]
     fn parse_ident() {
-        expect!(ident, "hello123", Ok("hello123".to_string()));
-        expect!(ident, "x", Ok("x".to_string()));
-        expect!(ident, "_x", Ok("_x".to_string()));
+        expect!(ident, "hello123", "hello123".to_string());
+        expect!(ident, "x", "x".to_string());
+        expect!(ident, "_x", "_x".to_string());
         // TODO: improve ergonomics of failure testing
         // expect!(ident,"5x", Ok("_x".to_string()));
     }
@@ -530,12 +782,12 @@ mod tests {
         expect!(
             var_list,
             "a, b, def, g_55",
-            Ok(vec![
+            vec![
                 "a".to_string(),
                 "b".to_string(),
                 "def".to_string(),
                 "g_55".to_string(),
-            ])
+            ]
         );
     }
 
@@ -544,20 +796,20 @@ mod tests {
         expect!(
             parse,
             r#"parse "[key=*]" as v"#,
-            Ok(InlineOperator::Parse {
+            InlineOperator::Parse {
                 pattern: Keyword::new_wildcard("[key=*]".to_string()),
                 fields: vec!["v".to_string()],
                 input_column: None,
-            },)
+            }
         );
         expect!(
             parse,
             r#"parse "[key=*]" as v"#,
-            Ok(InlineOperator::Parse {
+            InlineOperator::Parse {
                 pattern: Keyword::new_wildcard("[key=*]".to_string()),
                 fields: vec!["v".to_string()],
                 input_column: None,
-            },)
+            }
         );
     }
 
@@ -566,18 +818,16 @@ mod tests {
         expect!(
             operator,
             "  json",
-            Ok(Operator::Inline(InlineOperator::Json {
-                input_column: None
-            }))
+            Operator::Inline(InlineOperator::Json { input_column: None })
         );
         expect!(
             operator,
             r#" parse "[key=*]" from field as v "#,
-            Ok(Operator::Inline(InlineOperator::Parse {
+            Operator::Inline(InlineOperator::Parse {
                 pattern: Keyword::new_wildcard("[key=*]".to_string()),
                 fields: vec!["v".to_string()],
                 input_column: Some(Expr::Column("field".to_string())),
-            },))
+            })
         );
     }
 
@@ -586,24 +836,40 @@ mod tests {
         expect!(
             operator,
             " limit",
-            Ok(Operator::Inline(InlineOperator::Limit { count: None }))
+            Operator::Inline(InlineOperator::Limit { count: None })
         );
         expect!(
             operator,
             " limit 5",
-            Ok(Operator::Inline(InlineOperator::Limit { count: Some(5.0) }))
+            Operator::Inline(InlineOperator::Limit {
+                count: Some(Positioned {
+                    value: 5.0,
+                    start_pos: QueryPosition(7),
+                    end_pos: QueryPosition(8)
+                })
+            })
         );
         expect!(
             operator,
             " limit -5",
-            Ok(Operator::Inline(InlineOperator::Limit {
-                count: Some(-5.0),
-            }))
+            Operator::Inline(InlineOperator::Limit {
+                count: Some(Positioned {
+                    value: -5.0,
+                    start_pos: QueryPosition(7),
+                    end_pos: QueryPosition(9)
+                }),
+            })
         );
         expect!(
             operator,
             " limit 1e2",
-            Ok(Operator::Inline(InlineOperator::Limit { count: Some(1e2) }))
+            Operator::Inline(InlineOperator::Limit {
+                count: Some(Positioned {
+                    value: 1e2,
+                    start_pos: QueryPosition(7),
+                    end_pos: QueryPosition(10)
+                })
+            })
         );
     }
 
@@ -612,11 +878,18 @@ mod tests {
         expect!(
             multi_aggregate_operator,
             "count as renamed by x, y",
-            Ok(Operator::MultiAggregate(MultiAggregateOperator {
+            Operator::MultiAggregate(MultiAggregateOperator {
                 key_cols: vec![Expr::Column("x".to_string()), Expr::Column("y".to_string())],
                 key_col_headers: vec!["x".to_string(), "y".to_string()],
-                aggregate_functions: vec![("renamed".to_string(), AggregateFunction::Count)],
-            },))
+                aggregate_functions: vec![(
+                    "renamed".to_string(),
+                    Positioned {
+                        value: AggregateFunction::Count,
+                        start_pos: QueryPosition(0),
+                        end_pos: QueryPosition(5)
+                    }
+                )],
+            })
         );
     }
 
@@ -625,50 +898,58 @@ mod tests {
         expect!(
             complete_agg_function,
             "p50(x)",
-            Ok((
+            (
                 "p50".to_string(),
-                AggregateFunction::Percentile {
-                    column: Expr::Column("x".to_string()),
-                    percentile: 0.5,
-                    percentile_str: "50".to_string(),
+                Positioned {
+                    value: AggregateFunction::Percentile {
+                        column: Expr::Column("x".to_string()),
+                        percentile: 0.5,
+                        percentile_str: "50".to_string(),
+                    },
+                    start_pos: QueryPosition(0),
+                    end_pos: QueryPosition(6),
                 }
-            ),)
+            )
         );
     }
 
     #[test]
     fn query_no_operators() {
-        assert_eq!(
-            parse_query(" * "),
-            Ok(Query {
+        expect!(
+            query,
+            " * ",
+            Query {
                 search: vec![],
                 operators: vec![],
-            },)
+            }
         );
-        assert_eq!(
-            parse_query(" filter "),
-            Ok(Query {
+        expect!(
+            query,
+            " filter ",
+            Query {
                 search: vec![Keyword::new_wildcard("filter".to_string())],
                 operators: vec![],
-            },)
+            }
         );
-        assert_eq!(
-            parse_query(" *abc* "),
-            Ok(Query {
+        expect!(
+            query,
+            " *abc* ",
+            Query {
                 search: vec![Keyword::new_wildcard("abc".to_string())],
                 operators: vec![],
-            },)
+            }
         );
-        assert_eq!(
-            parse_query(" abc def \"*ghi*\" "),
-            Ok(Query {
+        expect!(
+            query,
+            " abc def \"*ghi*\" ",
+            Query {
                 search: vec![
                     Keyword::new_wildcard("abc".to_string()),
                     Keyword::new_wildcard("def".to_string()),
                     Keyword::new_exact("*ghi*".to_string()),
                 ],
                 operators: vec![],
-            },)
+            }
         );
     }
 
@@ -676,9 +957,10 @@ mod tests {
     fn query_operators() {
         let query_str =
             r#"* | json from col | parse "!123*" as foo | count by foo, foo == 123 | sort by foo dsc "#;
-        assert_eq!(
-            parse_query(query_str),
-            Ok(Query {
+        expect!(
+            query,
+            query_str,
+            Query {
                 search: vec![],
                 operators: vec![
                     Operator::Inline(InlineOperator::Json {
@@ -701,7 +983,11 @@ mod tests {
                         ],
                         aggregate_functions: vec![(
                             "_count".to_string(),
-                            AggregateFunction::Count {}
+                            Positioned {
+                                value: AggregateFunction::Count {},
+                                start_pos: QueryPosition(43),
+                                end_pos: QueryPosition(48),
+                            }
                         ),],
                     }),
                     Operator::Sort(SortOperator {
@@ -709,7 +995,7 @@ mod tests {
                         direction: SortMode::Descending,
                     }),
                 ],
-            },)
+            }
         );
     }
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -111,9 +111,16 @@ impl lang::InlineOperator {
 
                     error_builder
                         .report_error_for(e.to_string())
-                        .with_annotation(&count, "")
-                        .with_resolution("Use a positive value to select the first N rows")
-                        .with_resolution("Use a negative value to select the last N rows")
+                        .with_code_pointer(
+                            &count,
+                            if limit.fract() != 0.0 {
+                                "Fractional limits are not allowed"
+                            } else {
+                                "Zero is not allowed"
+                            },
+                        )
+                        .with_resolution("Use a positive integer to select the first N rows")
+                        .with_resolution("Use a negative integer to select the last N rows")
                         .send_report();
 
                     Err(e)
@@ -154,11 +161,11 @@ impl lang::Positioned<lang::AggregateFunction> {
                     _ => {
                         error_builder
                             .report_error_for("Expecting a single expression to count")
-                            .with_annotation(
+                            .with_code_pointer(
                                 &pos,
                                 match pos.value.len() {
-                                    0 => "No expression given".to_string(),
-                                    _ => "Only a single expression can be given".to_string(),
+                                    0 => "No expression given",
+                                    _ => "Only a single expression can be given",
                                 },
                             )
                             .with_resolution("example: count_distinct(field_to_count)")
@@ -171,7 +178,7 @@ impl lang::Positioned<lang::AggregateFunction> {
             lang::AggregateFunction::CountDistinct { column: None } => {
                 error_builder
                     .report_error_for("Expecting an expression to count")
-                    .with_annotation(&self, "No field argument given")
+                    .with_code_pointer(&self, "No field argument given")
                     .with_resolution("example: count_distinct(field_to_count)")
                     .send_report();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ struct TestDefinition {
     output: String,
     error: Option<String>,
     notes: Option<String>,
-    succeeds: Option<bool>
+    succeeds: Option<bool>,
 }
 
 #[cfg(test)]
@@ -33,8 +33,7 @@ mod integration {
         let conf: TestDefinition = toml::from_str(s).unwrap();
         let out: &str = conf.output.borrow();
         let err = conf.error.unwrap_or("".to_string());
-        let env = assert_cli::Environment::inherit()
-            .insert("RUST_BACKTRACE", "0");
+        let env = assert_cli::Environment::inherit().insert("RUST_BACKTRACE", "0");
         let mut asserter = assert_cli::Assert::main_binary()
             .with_env(env)
             .stdin(conf.input)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,36 +12,57 @@ struct TestDefinition {
     query: String,
     input: String,
     output: String,
+    error: Option<String>,
     notes: Option<String>,
 }
 
 #[cfg(test)]
 mod integration {
     use super::*;
-    use ag::pipeline::Pipeline;
+    use ag::pipeline::{ErrorReporter, Pipeline, QueryContainer};
     use assert_cli;
     use std::borrow::Borrow;
     use toml;
 
+    pub struct EmptyErrorReporter;
+
+    impl ErrorReporter for EmptyErrorReporter {}
+
     fn structured_test(s: &str) {
         let conf: TestDefinition = toml::from_str(s).unwrap();
         let out: &str = conf.output.borrow();
+        let err = conf.error.unwrap_or("".to_string());
+        let env = assert_cli::Environment::inherit()
+            .insert("RUST_BACKTRACE", "0")
+            .insert("NO_COLOR", "");
         assert_cli::Assert::main_binary()
+            .with_env(&env)
             .stdin(conf.input)
             .with_args(&[&conf.query])
             .stdout()
             .is(out)
+            .stderr()
+            .is(err.as_str())
+            .ignore_status()
             .unwrap();
     }
 
     #[test]
     fn count_distinct_operator() {
         structured_test(include_str!("structured_tests/count_distinct.toml"));
+        structured_test(include_str!("structured_tests/count_distinct_error.toml"));
     }
 
     #[test]
     fn long_aggregate_values() {
         structured_test(include_str!("structured_tests/longlines.toml"));
+    }
+
+    #[test]
+    fn parse_operator() {
+        structured_test(include_str!(
+            "structured_tests/parse_error_unterminated.toml"
+        ));
     }
 
     #[test]
@@ -92,7 +113,7 @@ mod integration {
             .fails()
             .and()
             .stderr()
-            .contains("Failure parsing")
+            .contains("Failed to parse query")
             .unwrap();
     }
 
@@ -244,7 +265,8 @@ $None$       1")
     }
 
     fn ensure_parses(query: &str) {
-        Pipeline::new(query).expect(&format!(
+        let query_container = QueryContainer::new(query.to_string(), Box::new(EmptyErrorReporter));
+        Pipeline::new(&query_container).expect(&format!(
             "Query: `{}` from the README should have parsed",
             query
         ));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -53,7 +53,7 @@ mod integration {
 
     #[test]
     fn count_distinct_operator() {
-        // structured_test(include_str!("structured_tests/count_distinct.toml"));
+        structured_test(include_str!("structured_tests/count_distinct.toml"));
         structured_test(include_str!("structured_tests/count_distinct_error.toml"));
     }
 

--- a/tests/structured_tests/count_distinct_error.toml
+++ b/tests/structured_tests/count_distinct_error.toml
@@ -1,0 +1,15 @@
+query = "* | json | count, count_distinct"
+input = """
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": "error", "message": "Oh now an error!"}
+"""
+output = ""
+error = """
+error: Expecting an expression to count
+  |
+1 | * | json | count, count_distinct
+  |                   ^^^^^^^^^^^^^^
+  |
+  = help: example: count_distinct(field_to_count)
+Error: Failed to parse query
+"""

--- a/tests/structured_tests/count_distinct_error.toml
+++ b/tests/structured_tests/count_distinct_error.toml
@@ -8,8 +8,9 @@ error = """
 error: Expecting an expression to count
   |
 1 | * | json | count, count_distinct
-  |                   ^^^^^^^^^^^^^^
+  |                   ^^^^^^^^^^^^^^ No field argument given
   |
   = help: example: count_distinct(field_to_count)
 Error: Failed to parse query
 """
+succeeds = false

--- a/tests/structured_tests/parse_error_unterminated.toml
+++ b/tests/structured_tests/parse_error_unterminated.toml
@@ -5,7 +5,7 @@ input = """
 """
 output = ""
 error = """
-error: unterminated double quote string
+error: unterminated double quoted string
   |
 1 | * | parse "abc
   |           ^^^^
@@ -13,3 +13,4 @@ error: unterminated double quote string
   = help: Insert a double quote to terminate this string
 Error: Failed to parse query
 """
+succeeds = false

--- a/tests/structured_tests/parse_error_unterminated.toml
+++ b/tests/structured_tests/parse_error_unterminated.toml
@@ -1,0 +1,15 @@
+query = "* | parse \"abc"
+input = """
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": "error", "message": "Oh now an error!"}
+"""
+output = ""
+error = """
+error: unterminated double quote string
+  |
+1 | * | parse "abc
+  |           ^^^^
+  |
+  = help: Insert a double quote to terminate this string
+Error: Failed to parse query
+"""


### PR DESCRIPTION
Informative parser error messages can go a long way towards making
this tool easier to use.  This change tries to lay some groundwork
for catching common errors and reporting meaningful error messages.

First, the nom_locate crate has been added and nom's "verbose-errors"
feature has been enabled so that more information can be gained
about were parse errors occur and where values are coming from in
the query.  I've also started changing the grammar to make it more
lax so that more problems are treated as semantic errors instead
of parse errors.  For example, having the parse fail because there
are no arguments passed to count_distinct is not friendly.  Instead,
the parse now succeeds and the error is raised later on.  In the
future, I'd like to raise that type of error even later so that
a set of fields to use can be suggested.  Reporting errors is done
through the annotate-snippets crate which generates nice error
messages like in rustc.

The only errors I'm tackling in this first pass are unterminated
quotes and parentheses, as well as the count_distinct() aggregate
function.

Files:
  * Cargo.toml: Enable the verbose-errors feature in nom so that
    we can get more error info.  The nom_locate crate makes it a
    little easier to track the position of values in the query.
    The annotate-snippets library makes it easy to report errors
    in a pretty manner.
  * agrind.rs: Print parse errors to stderr.
  * lang.rs: Use nom_locate's LocatedSpan as the input type.
    Start to rework the grammar to be more lax.  Added some
    infrastructure for reporting errors.
  * lib.rs, typecheck.rs: Move the building of aggregate functions
    into typecheck to match how inline operators work.