### PR TITLE
Build Windows with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ branches:
     # release tags
     - /^v\d+\.\d+\.\d+.*$/
     - master
+    - build-windows
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ matrix:
       os: osx
       rust: stable
 
+    # Windows
+    - env: TARGET=x86_64-pc-windows-msvc NATIVE_BUILD=1
+      os: windows
+      rust: stable
+
     # Testing other channels
     - env: TARGET=x86_64-unknown-linux-musl
       rust: nightly

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -33,7 +33,7 @@ main() {
     cd $stage
     case $TRAVIS_OS_NAME in
         windows)
-            zip $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.zip *
+            7z a $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.zip *
             ;;
         *)
             tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -31,7 +31,14 @@ main() {
     cp target/$TARGET/release/agrind $stage/
 
     cd $stage
-    tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *
+    case $TRAVIS_OS_NAME in
+        windows)
+            zip $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.zip *
+            ;;
+        *)
+            tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *
+            ;;
+    esac
     cd $src
 
     rm -rf $stage

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -8,7 +8,7 @@ main() {
           stage=
 
     case $TRAVIS_OS_NAME in
-        linux)
+        linux | windows)
             stage=$(mktemp -d)
             ;;
         osx)
@@ -16,10 +16,16 @@ main() {
             ;;
     esac
 
+
     test -f Cargo.lock || cargo generate-lockfile
 
     # TODO Update this to build the artifacts that matter to you
-    cross rustc --bin agrind --target $TARGET --release -- -C lto
+
+    if [ "$NATIVE_BUILD" ]; then
+        cargo rustc --bin agrind --target $TARGET --release -- -C lto
+    else
+        cross rustc --bin agrind --target $TARGET --release -- -C lto
+    fi
 
     # TODO Update this to package the right artifacts
     cp target/$TARGET/release/agrind $stage/

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -44,4 +44,6 @@ main() {
            --target $target
 }
 
-main
+if [ -z $NATIVE_BUILD ]; then
+    main
+fi

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -44,6 +44,8 @@ main() {
            --target $target
 }
 
-if [ -z $NATIVE_BUILD ]; then
-    main
+if [ "$NATIVE_BUILD" ]; then
+    exit 0
 fi
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # TODO This is the "test phase", tweak it as you see fit
-main() {
+main_cross() {
     cross build --target $TARGET
     cross build --target $TARGET --release
 
@@ -18,7 +18,29 @@ main() {
     cross run --target $TARGET --release -- --help
 }
 
+main_cargo() {
+    cargo build --target $TARGET
+    cargo build --target $TARGET --release
+
+    if [ ! -z $DISABLE_TESTS ]; then
+        return
+    fi
+
+    cargo test --target $TARGET
+    cargo test --target $TARGET --release
+
+    cargo run --target $TARGET -- --help
+    cargo run --target $TARGET --release -- --help
+}
+
 # we don't run the "test phase" when doing deploys
-if [ -z $TRAVIS_TAG ]; then
-    main
+if [ -n $TRAVIS_TAG ]; then
+    exit 0
 fi
+
+if [ -z $NATIVE_BUILD]; then
+    main_cargo
+else
+    main_cross
+fi
+

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -7,7 +7,7 @@ main_cross() {
     cross build --target $TARGET
     cross build --target $TARGET --release
 
-    if [ ! -z $DISABLE_TESTS ]; then
+    if [ "$DISABLE_TESTS" ]; then
         return
     fi
 
@@ -22,7 +22,7 @@ main_cargo() {
     cargo build --target $TARGET
     cargo build --target $TARGET --release
 
-    if [ ! -z $DISABLE_TESTS ]; then
+    if [ "$DISABLE_TESTS" ]; then
         return
     fi
 
@@ -34,11 +34,11 @@ main_cargo() {
 }
 
 # we don't run the "test phase" when doing deploys
-if [ -n $TRAVIS_TAG ]; then
+if [ "$TRAVIS_TAG" ]; then
     exit 0
 fi
 
-if [ -z $NATIVE_BUILD]; then
+if [ "$NATIVE_BUILD" ]; then
     main_cargo
 else
     main_cross


### PR DESCRIPTION
This sets up Travis' semi-new Windows building capability. I was interested in how easily Travis' infrastructure would work - turns out it was surprisingly easy, I did not hit any snags at all (apart from build time).

I used the -msvc target, which `cross` does not support - to get around this I am using `cargo` directly in the build scripts instead of `cross` when building Windows.

Windows builds are kind of slow (uncached, around 40 minutes), a lot of this is due to slow Rust installation.

Releases built from this are available in my fork - https://github.com/akdor1154/angle-grinder/releases . 

All tests pass and basic functionality seems to work with no code changes needed, you seem to have a very nice codebase. :)