### PR TITLE
Parse nodrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ specified.
 ![json.gif](/screen_shots/json.gif)
 
 ##### Parse
-`parse "* pattern * otherpattern *" [from field] as a,b,c`: Parse text that matches the pattern into variables. Lines that don't match the pattern will be dropped. `*` is equivalent to regular expression `.*` and is greedy. 
+`parse "* pattern * otherpattern *" [from field] as a,b,c [nodrop]`: Parse text that matches the pattern into variables. Lines that don't match the pattern will be dropped unless `nodrop` is specified. `*` is equivalent to regular expression `.*` and is greedy.
 By default, `parse` operates on the raw text of the message. With `from field_name`, parse will instead process input from a specific column.
 
 *Examples*:

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -175,9 +175,9 @@ pub enum SortMode {
     Descending,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Eq, Hash)]
 pub enum ParseOption {
-    NoDrop
+    NoDrop,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -70,6 +70,7 @@ impl lang::InlineOperator {
                 pattern,
                 fields,
                 input_column,
+                parse_options
             } => {
                 let regex = pattern.to_regex();
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2,6 +2,7 @@ use crate::data::Value;
 use crate::errors::ErrorBuilder;
 use crate::lang;
 use crate::operator;
+use std::collections::HashSet;
 
 #[derive(Debug, Fail)]
 pub enum TypeError {
@@ -74,6 +75,8 @@ impl lang::InlineOperator {
             } => {
                 let regex = pattern.to_regex();
 
+                let options: HashSet<lang::ParseOption> = parse_options.iter().cloned().collect();
+
                 if (regex.captures_len() - 1) != fields.len() {
                     Err(TypeError::ParseNumPatterns {
                         pattern: regex.captures_len() - 1,
@@ -84,6 +87,9 @@ impl lang::InlineOperator {
                         regex,
                         fields,
                         input_column.map(|e| e.into()),
+                        operator::ParseOptions {
+                            drop_nonmatching: options.contains(&lang::ParseOption::NoDrop)
+                        }
                     )))
                 }
             }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2,7 +2,6 @@ use crate::data::Value;
 use crate::errors::ErrorBuilder;
 use crate::lang;
 use crate::operator;
-use std::collections::HashSet;
 
 #[derive(Debug, Fail)]
 pub enum TypeError {
@@ -71,11 +70,9 @@ impl lang::InlineOperator {
                 pattern,
                 fields,
                 input_column,
-                parse_options
+                no_drop,
             } => {
                 let regex = pattern.to_regex();
-
-                let options: HashSet<lang::ParseOption> = parse_options.iter().cloned().collect();
 
                 if (regex.captures_len() - 1) != fields.len() {
                     Err(TypeError::ParseNumPatterns {
@@ -88,8 +85,8 @@ impl lang::InlineOperator {
                         fields,
                         input_column.map(|e| e.into()),
                         operator::ParseOptions {
-                            drop_nonmatching: options.contains(&lang::ParseOption::NoDrop)
-                        }
+                            drop_nonmatching: !no_drop,
+                        },
                     )))
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -67,6 +67,8 @@ mod integration {
         structured_test(include_str!(
             "structured_tests/parse_error_unterminated.toml"
         ));
+        structured_test(include_str!("structured_tests/parse_drop.toml"));
+        structured_test(include_str!("structured_tests/parse_nodrop.toml"));
     }
 
     #[test]
@@ -212,7 +214,7 @@ $None$       1")
         assert_cli::Assert::main_binary()
             .with_args(&[
                 r#"* "error" | parse "* *" as lev, js
-                     | json from js 
+                     | json from js
                      | fields except js, lev"#,
                 "--file",
                 "test_files/test_partial_json.log",

--- a/tests/structured_tests/parse_drop.toml
+++ b/tests/structured_tests/parse_drop.toml
@@ -1,0 +1,10 @@
+query = """* | parse "name=* says=*" as name, words"""
+input = """
+name=Jarrad says=Hi
+name=Ella says=Bye
+name=Jim
+"""
+output = """
+[name=Jarrad]        [words=Hi]
+[name=Ella]          [words=Bye]
+"""

--- a/tests/structured_tests/parse_nodrop.toml
+++ b/tests/structured_tests/parse_nodrop.toml
@@ -1,0 +1,11 @@
+query = """* | parse "name=* says=*" as name, words nodrop"""
+input = """
+name=Jarrad says=Hi
+name=Ella says=Bye
+name=Jim
+"""
+output = """
+[name=Jarrad]        [words=Hi]
+[name=Ella]          [words=Bye]
+[name=$None$]        [words=$None$]
+"""


### PR DESCRIPTION
Implement `nodrop` option for `parse`, which leaves non-matching lines in the logs with the parsed fields set to None.

Code comments welcome however trivial, I'm quite new to Rust.