### PR TITLE
[expr] add a not (!) operator for expressions

### DIFF
--- a/src/lang.rs
+++ b/src/lang.rs
@@ -71,8 +71,17 @@ pub enum BinaryOp {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub enum UnaryOp {
+    Not,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Expr {
     Column(String),
+    Unary {
+        op: UnaryOp,
+        operand: Box<Expr>,
+    },
     Binary {
         op: BinaryOp,
         left: Box<Expr>,
@@ -280,12 +289,21 @@ named!(comp_op<Span, ComparisonOp>, ws!(alt!(
     | map!(tag!("<"), |_|ComparisonOp::Lt)
 )));
 
+named!(unary_op<Span, UnaryOp>, ws!(alt!(
+    map!(tag!("!"), |_|UnaryOp::Not)
+)));
+
 named!(expr<Span, Expr>, ws!(alt!(
     do_parse!(
         l: e_ident >>
         comp: comp_op >>
         r: e_ident >>
         ( Expr::Binary { op: BinaryOp::Comparison(comp), left: Box::new(l), right: Box::new(r)} )
+    )
+    | do_parse!(
+        op: unary_op >>
+        operand: e_ident >>
+        ( Expr::Unary { op, operand: Box::new(operand) } )
     )
     | e_ident
 )));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -84,6 +84,8 @@ mod integration {
         structured_test(include_str!("structured_tests/where-1.toml"));
         structured_test(include_str!("structured_tests/where-2.toml"));
         structured_test(include_str!("structured_tests/where-3.toml"));
+        structured_test(include_str!("structured_tests/where-4.toml"));
+        structured_test(include_str!("structured_tests/where-5.toml"));
     }
 
     #[test]

--- a/tests/structured_tests/where-4.toml
+++ b/tests/structured_tests/where-4.toml
@@ -1,0 +1,9 @@
+query = """* | json | where !bval"""
+input = """
+{"thing_a": 5, "bval": true}
+{"thing_a": 6, "bval": false}
+{"thing_a": 0, "bval": true}
+"""
+output = """
+[bval=false]        [thing_a=6]
+"""

--- a/tests/structured_tests/where-5.toml
+++ b/tests/structured_tests/where-5.toml
@@ -1,0 +1,10 @@
+query = """* | json | where bval"""
+input = """
+{"thing_a": 5, "bval": true}
+{"thing_a": 6, "bval": false}
+{"thing_a": 0, "bval": true}
+"""
+output = """
+[bval=true]        [thing_a=5]
+[bval=true]        [thing_a=0]
+"""


### PR DESCRIPTION
Initial implementation of a not (!) unary operator for expressions.
I can't find a complete language reference for sumologic, so I'm
not sure how the operator behaves with non-boolean values.  This
first version is conservative and raises an error if the value is
not a boolean.

Files:
  * lang.rs: Add the syntax for the (!) unary operator
  * operators.rs: Implement the ! operation
  * typecheck.rs: Convert the syntax tree to the operator
    representation