### PR TITLE
[lang] make inline operators positioned to give better error messages

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -137,6 +137,7 @@ pub struct SnippetData {
     resolution: Vec<String>,
 }
 
+#[must_use = "the send_report() method must eventually be called for this builder"]
 pub struct SnippetBuilder<'a> {
     query: &'a QueryContainer,
     data: SnippetData,

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -13,12 +13,14 @@ use std::str;
 macro_rules! with_pos {
   ($i:expr, $submac:ident!( $($args:tt)* )) => ({
       // XXX The ws!() combinator does not mix well with custom combinators since it does some
-      // rewriting, but only for things it knows about.
+      // rewriting, but only for things it knows about.  So, we put the ws!() combinator inside
+      // calls to with_pos!() and have with_pos!() eat up any initial space with space0().
       match space0($i) {
           Err(e) => Err(e),
-          Ok((i1, _o)) => { let start_pos: QueryPosition = i1.into();
+          Ok((i1, _o)) => {
+              let start_pos: QueryPosition = i1.into();
               match $submac!(i1, $($args)*) {
-                  Ok((i,o)) => Ok((i, Positioned {
+                  Ok((i, o)) => Ok((i, Positioned {
                       start_pos,
                       value: o,
                       end_pos: i.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,10 @@ pub mod pipeline {
                             post_agg.push(op);
 
                             let needs_sort = match op_iter.peek() {
-                                Some(Operator::Inline(InlineOperator::Limit { .. })) => true,
+                                Some(Operator::Inline(Positioned {
+                                    value: InlineOperator::Limit { .. },
+                                    ..
+                                })) => true,
                                 None => true,
                                 _ => false,
                             };

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -116,18 +116,22 @@ impl lang::Positioned<lang::InlineOperator> {
                 ) => Ok(Box::new(operator::Where::new(unop))),
                 operator::Expr::Column(name) => Ok(Box::new(operator::Where::new(name))),
                 operator::Expr::Value(constant) => {
-                    let e = TypeError::ExpectedBool {
-                        found: format!("{:?}", constant),
-                    };
+                    if let Value::Bool(bool_value) = constant {
+                        Ok(Box::new(operator::Where::new(*bool_value)))
+                    } else {
+                        let e = TypeError::ExpectedBool {
+                            found: format!("{:?}", constant),
+                        };
 
-                    error_builder
-                        .report_error_for(&e)
-                        .with_code_range(expr.start_pos, expr.end_pos, "This is constant")
-                        .with_resolution("Perhaps you meant to compare a field to this value?")
-                        .with_resolution(format!("example: where field1 == {}", constant))
-                        .send_report();
+                        error_builder
+                            .report_error_for(&e)
+                            .with_code_range(expr.start_pos, expr.end_pos, "This is constant")
+                            .with_resolution("Perhaps you meant to compare a field to this value?")
+                            .with_resolution(format!("example: where field1 == {}", constant))
+                            .send_report();
 
-                    Err(e)
+                        Err(e)
+                    }
                 }
             },
             lang::InlineOperator::Where { expr: None } => {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -8,6 +8,9 @@ pub enum TypeError {
     #[fail(display = "Expected boolean expression, found {}", found)]
     ExpectedBool { found: String },
 
+    #[fail(display = "Expected an expression")]
+    ExpectedExpr,
+
     #[fail(
         display = "Wrong number of patterns for parse. Pattern has {} but {} were extracted",
         pattern, extracted
@@ -61,14 +64,14 @@ impl From<lang::Expr> for operator::Expr {
 
 const DEFAULT_LIMIT: i64 = 10;
 
-impl lang::InlineOperator {
+impl lang::Positioned<lang::InlineOperator> {
     /// Convert the operator syntax to a builder that can instantiate an operator for the
     /// pipeline.  Any semantic errors in the operator syntax should be detected here.
     pub fn semantic_analysis<T: ErrorBuilder>(
         self,
         error_builder: &T,
     ) -> Result<Box<operator::OperatorBuilder + Send + Sync>, TypeError> {
-        match self {
+        match self.value {
             lang::InlineOperator::Json { input_column } => {
                 Ok(Box::new(operator::ParseJson::new(input_column)))
             }
@@ -103,7 +106,7 @@ impl lang::InlineOperator {
                 };
                 Ok(Box::new(operator::Fields::new(&fields, omode)))
             }
-            lang::InlineOperator::Where { expr } => match expr.into() {
+            lang::InlineOperator::Where { expr: Some(expr) } => match expr.value.into() {
                 operator::Expr::Comparison(binop) => Ok(Box::new(operator::Where::new(binop))),
                 operator::Expr::BoolUnary(
                     unop @ operator::UnaryExpr {
@@ -112,10 +115,36 @@ impl lang::InlineOperator {
                     },
                 ) => Ok(Box::new(operator::Where::new(unop))),
                 operator::Expr::Column(name) => Ok(Box::new(operator::Where::new(name))),
-                other => Err(TypeError::ExpectedBool {
-                    found: format!("{:?}", other),
-                }),
+                operator::Expr::Value(constant) => {
+                    let e = TypeError::ExpectedBool {
+                        found: format!("{:?}", constant),
+                    };
+
+                    error_builder
+                        .report_error_for(&e)
+                        .with_code_range(expr.start_pos, expr.end_pos, "This is constant")
+                        .with_resolution("Perhaps you meant to compare a field to this value?")
+                        .with_resolution(format!("example: where field1 == {}", constant))
+                        .send_report();
+
+                    Err(e)
+                }
             },
+            lang::InlineOperator::Where { expr: None } => {
+                let e = TypeError::ExpectedExpr;
+
+                error_builder
+                    .report_error_for(&e)
+                    .with_code_pointer(&self, "No condition provided for this 'where'")
+                    .with_resolution(
+                        "Insert an expression whose result determines whether a record should be \
+                         passed downstream",
+                    )
+                    .with_resolution("example: where duration > 100")
+                    .send_report();
+
+                Err(e)
+            }
             lang::InlineOperator::Limit { count: Some(count) } => match count.value {
                 limit if limit.trunc() == 0.0 || limit.fract() != 0.0 => {
                     let e = TypeError::InvalidLimit { limit };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -86,6 +86,8 @@ mod integration {
         structured_test(include_str!("structured_tests/where-3.toml"));
         structured_test(include_str!("structured_tests/where-4.toml"));
         structured_test(include_str!("structured_tests/where-5.toml"));
+        structured_test(include_str!("structured_tests/where-6.toml"));
+        structured_test(include_str!("structured_tests/where-7.toml"));
     }
 
     #[test]

--- a/tests/structured_tests/where-6.toml
+++ b/tests/structured_tests/where-6.toml
@@ -1,0 +1,16 @@
+query = """* | json | where"""
+input = """
+{"thing_a": 5, "bval": true}
+"""
+output = """"""
+error = """
+error: Expected an expression
+  |
+1 | * | json | where
+  |            ^^^^^ No condition provided for this 'where'
+  |
+  = help: Insert an expression whose result determines whether a record should be passed downstream
+  = help: example: where duration > 100
+Error: Expected an expression
+"""
+succeeds = false

--- a/tests/structured_tests/where-7.toml
+++ b/tests/structured_tests/where-7.toml
@@ -1,0 +1,16 @@
+query = """* | json | where 1"""
+input = """
+{"thing_a": 5, "bval": true}
+"""
+output = """"""
+error = """
+error: Expected boolean expression, found Int(1)
+  |
+1 | * | json | where 1
+  |                  ^ This is constant
+  |
+  = help: Perhaps you meant to compare a field to this value?
+  = help: example: where field1 == 1
+Error: Expected boolean expression, found Int(1)
+"""
+succeeds = false


### PR DESCRIPTION
This change tries to add some more detailed error messages for the
'where' operator.

Files:
  * errors.rs: Forgot to mark the SnippetBuilder as "must_use" so that
    calling send_report() is not forgotten.
  * lang.rs: Wrap InlineOperators with Positioned so we can give better
    error messages for them as well.
  * typecheck.rs: Add some more detailed errors for the 'where'
    operator.