### PR TITLE
[panic] handle stdout being closed gracefully

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -1,4 +1,5 @@
 use crate::data;
+use failure::Error;
 use std;
 use std::collections::HashMap;
 use std::io::{stdout, Write};
@@ -275,7 +276,7 @@ impl Renderer {
         }
     }
 
-    pub fn render(&mut self, row: &data::Row, last_row: bool) {
+    pub fn render(&mut self, row: &data::Row, last_row: bool) -> Result<(), Error> {
         match *row {
             data::Row::Aggregate(ref aggregate) => {
                 if !self.is_tty {
@@ -290,10 +291,14 @@ impl Renderer {
                     self.reset_sequence = "\x1b[2K\x1b[1A".repeat(num_lines);
                     self.last_print = Some(Instant::now());
                 }
+
+                Ok(())
             }
             data::Row::Record(ref record) => {
                 let output = self.pretty_printer.format_record(record);
-                writeln!(self.stdout, "{}", output).unwrap();
+                writeln!(self.stdout, "{}", output)?;
+
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
Redirecting the output of agrind to "head" results in a
panic since the result of the writeln!() is unwrapped.
This change checks the result and drops out of the render
thread.  The main thread then bombs out when trying to
send records to the renderer.

Not sure the best way to test this...

Files:
  * lib.rs: Check for errors from the renderer and drop
    out of the loopers.
  * render.rs: Return a Result from render()