### PR TITLE
Fix typo in version message

### DIFF
--- a/src/bin/agrind.rs
+++ b/src/bin/agrind.rs
@@ -102,7 +102,7 @@ fn update() -> CliResult {
 
     if cargo_crate_version!() == status.version() {
         println!(
-            "Currently running a newer version than publicly available ({}). No changes",
+            "Currently running the latest version publicly available ({}). No changes",
             status.version()
         );
     } else {

--- a/src/bin/agrind.rs
+++ b/src/bin/agrind.rs
@@ -102,7 +102,7 @@ fn update() -> CliResult {
 
     if cargo_crate_version!() == status.version() {
         println!(
-            "Currently running a new version than publicly available ({}). No changes",
+            "Currently running a newer version than publicly available ({}). No changes",
             status.version()
         );
     } else {


### PR DESCRIPTION
Change 'new version than' to 'newer version than'