### PR TITLE
DRY out one section of the syntax error system

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,13 +30,14 @@ pub enum SyntaxErrors {
 }
 
 // Used to generate suggestions
-const VALID_OPERATORS: [&'static str; 12] = [
+pub const VALID_OPERATORS: [&'static str; 13] = [
     // inline
     "parse",
     "limit",
     "json",
     "total",
     "fields",
+    "where",
     // aggregates
     "count",
     "average",

--- a/tests/structured_tests/count_distinct_error_2.toml
+++ b/tests/structured_tests/count_distinct_error_2.toml
@@ -1,6 +1,5 @@
 query = "* | json | countdistinct(a)"
-input = """
-"""
+input = ""
 output = ""
 error = """
 error: Expected an operator
@@ -11,6 +10,5 @@ error: Expected an operator
   = help: countdistinct is not a valid operator
   = help: Did you mean "count_distinct"?
 Error: Failed to parse query
-
 """
 succeeds = false


### PR DESCRIPTION
Turns out I had left out `where`, so I guess it wasn't just a yak shave