### PR TITLE
Generate hints for aggregate functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom_locate 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ num-derive = "0.2.3"
 num-traits = "0.2.6"
 annotate-snippets = { version = "0.5.0", features = ["ansi_term"] }
 atty = "0.2.0"
+lazy_static = "1.2.0"
 
 [dev-dependencies]
 assert_cli = "0.6.3"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -137,7 +137,7 @@ impl SyntaxErrors {
                     res.push(format!("Did you mean \"{}\"?", choice));
                 }
                 if VALID_INLINE.contains(&code_fragment) {
-                    res.push(format!("{} is an inline operator, but only aggregate operators (count, average, egc.) are valid here", code_fragment))
+                    res.push(format!("{} is an inline operator, but only aggregate operators (count, average, etc.) are valid here", code_fragment))
                 }
                 res
             }
@@ -284,7 +284,7 @@ mod tests {
             SyntaxErrors::NotAnAggregateOperator.to_resolution("parse"),
             vec![
                 "parse is not a valid aggregate operator",
-                "parse is an inline operator, but only aggregate operators (count, average, egc.) are valid here"
+                "parse is an inline operator, but only aggregate operators (count, average, etc.) are valid here"
             ]
         );
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -114,7 +114,8 @@ mod integration {
         structured_test(include_str!("structured_tests/limit_error.toml"));
         structured_test(include_str!("structured_tests/limit_error_2.toml"));
         structured_test(include_str!("structured_tests/count_distinct_error_2.toml"));
-        structured_test(include_str!("structured_tests/not_an_agg.toml"))
+        structured_test(include_str!("structured_tests/not_an_agg.toml"));
+        structured_test(include_str!("structured_tests/not_an_agg_2.toml"))
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -114,6 +114,7 @@ mod integration {
         structured_test(include_str!("structured_tests/limit_error.toml"));
         structured_test(include_str!("structured_tests/limit_error_2.toml"));
         structured_test(include_str!("structured_tests/count_distinct_error_2.toml"));
+        structured_test(include_str!("structured_tests/not_an_agg.toml"))
     }
 
     #[test]

--- a/tests/structured_tests/not_an_agg.toml
+++ b/tests/structured_tests/not_an_agg.toml
@@ -8,7 +8,7 @@ error: Not an aggregate operator
   |                   ^^^^^
   |
   = help: parse is not a valid aggregate operator
-  = help: parse is an inline operator, but only aggregate operators (count, average, egc.) are valid here
+  = help: parse is an inline operator, but only aggregate operators (count, average, etc.) are valid here
 Error: Failed to parse query
 """
 succeeds = false

--- a/tests/structured_tests/not_an_agg.toml
+++ b/tests/structured_tests/not_an_agg.toml
@@ -1,0 +1,14 @@
+query = "* | json | count, parse by foo"
+input = ""
+output = ""
+error = """
+error: Not an aggregate operator
+  |
+1 | * | json | count, parse by foo
+  |                   ^^^^^
+  |
+  = help: parse is not a valid aggregate operator
+  = help: parse is an inline operator, but only aggregate operators (count, average, egc.) are valid here
+Error: Failed to parse query
+"""
+succeeds = false

--- a/tests/structured_tests/not_an_agg_2.toml
+++ b/tests/structured_tests/not_an_agg_2.toml
@@ -1,0 +1,14 @@
+query = "* | json | count, averag(c) by foo"
+input = ""
+output = ""
+error = """
+error: Not an aggregate operator
+  |
+1 | * | json | count, averag(c) by foo
+  |                   ^^^^^^
+  |
+  = help: averag is not a valid aggregate operator
+  = help: Did you mean "average"?
+Error: Failed to parse query
+"""
+succeeds = false


### PR DESCRIPTION
Finishing #61, we now also provide error suggestions for aggregate operators and give a special hint if you put an inline operator where an aggregate should go 