### PR TITLE
Implement Support for complex filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ag"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "annotate-snippets 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ag"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Russell Cohen <russell.r.cohen@gmail.com>"]
 description = "CLI App to slice and dice logfiles"
 license = "MIT"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -12,7 +12,7 @@ impl Filter {
             Filter::Keyword(regex) => regex.is_match(inp),
             Filter::And(clauses) => clauses.iter().all(|clause| clause.matches(inp)),
             Filter::Or(clauses) => clauses.iter().any(|clause| clause.matches(inp)),
-            Filter::Not(clause) => !clause.matches(inp)
+            Filter::Not(clause) => !clause.matches(inp),
         }
     }
 }
@@ -65,6 +65,5 @@ mod tests {
         assert_eq!(filt.matches("abc"), false);
         assert_eq!(filt.matches("123 456"), true);
         assert_eq!(filt.matches("123 cde"), false);
-
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,70 @@
+#[derive(Debug)]
+pub enum Filter {
+    And(Vec<Filter>),
+    Or(Vec<Filter>),
+    Not(Box<Filter>),
+    Keyword(regex::Regex),
+}
+
+impl Filter {
+    pub fn matches(&self, inp: &str) -> bool {
+        match self {
+            Filter::Keyword(regex) => regex.is_match(inp),
+            Filter::And(clauses) => clauses.iter().all(|clause| clause.matches(inp)),
+            Filter::Or(clauses) => clauses.iter().any(|clause| clause.matches(inp)),
+            Filter::Not(clause) => !clause.matches(inp)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::Keyword;
+
+    pub fn from_str(inp: &str) -> Filter {
+        Filter::Keyword(Keyword::new_exact(inp.to_owned()).to_regex())
+    }
+
+    #[test]
+    fn filter_and() {
+        let filt = Filter::And(vec![from_str("abc"), from_str("cde")]);
+        assert_eq!(filt.matches("abc cde"), true);
+        assert_eq!(filt.matches("abc"), false);
+    }
+
+    #[test]
+    fn filter_or() {
+        let filt = Filter::Or(vec![from_str("abc"), from_str("cde")]);
+        assert_eq!(filt.matches("abc cde"), true);
+        assert_eq!(filt.matches("abc"), true);
+        assert_eq!(filt.matches("cde"), true);
+        assert_eq!(filt.matches("def"), false);
+    }
+
+    #[test]
+    fn filter_wildcard() {
+        let filt = Filter::And(vec![]);
+        assert_eq!(filt.matches("abc"), true);
+    }
+
+    #[test]
+    fn filter_not() {
+        let filt = Filter::And(vec![from_str("abc"), from_str("cde")]);
+        let filt = Filter::Not(Box::new(filt));
+        assert_eq!(filt.matches("abc cde"), false);
+        assert_eq!(filt.matches("abc"), true);
+    }
+
+    #[test]
+    fn filter_complex() {
+        let filt_letters = Filter::And(vec![from_str("abc"), from_str("cde")]);
+        let filt_numbers = Filter::And(vec![from_str("123"), from_str("456")]);
+        let filt = Filter::Or(vec![filt_letters, filt_numbers]);
+        assert_eq!(filt.matches("abc cde"), true);
+        assert_eq!(filt.matches("abc"), false);
+        assert_eq!(filt.matches("123 456"), true);
+        assert_eq!(filt.matches("123 cde"), false);
+
+    }
+}

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -38,12 +38,12 @@ macro_rules! with_pos {
 
 /// Dynamic version of `alt` that takes a slice of strings
 fn alternative<T>(input: T, alternatives: &[&'static str]) -> IResult<T, T>
-    where
-        T: InputTake,
-        T: Compare<&'static str>,
-        T: InputLength,
-        T: AtEof,
-        T: Clone,
+where
+    T: InputTake,
+    T: Compare<&'static str>,
+    T: InputLength,
+    T: AtEof,
+    T: Clone,
 {
     let mut last_err = None;
     for alternative in alternatives {
@@ -73,11 +73,7 @@ lazy_static! {
         { [VALID_INLINE, VALID_AGGREGATES].concat() };
 }
 
-pub const RESERVED_FILTER_WORDS: &'static [&str] = &[
-    "AND",
-    "OR",
-    "NOT"
-];
+pub const RESERVED_FILTER_WORDS: &'static [&str] = &["AND", "OR", "NOT"];
 
 /// Type used to track the current fragment being parsed and its location in the original input.
 pub type Span<'a> = LocatedSpan<CompleteStr<'a>>;
@@ -200,7 +196,7 @@ impl Search {
     fn no_op(&self) -> bool {
         match self {
             Search::Keyword(Keyword(k, _)) => k.is_empty(),
-            _ => false
+            _ => false,
         }
     }
 }
@@ -284,7 +280,6 @@ pub struct SortOperator {
     pub sort_cols: Vec<String>,
     pub direction: SortMode,
 }
-
 
 #[derive(Debug, PartialEq)]
 pub struct Query {
@@ -994,7 +989,9 @@ mod tests {
             query,
             " filter ",
             Query {
-                search: Search::And(vec![Search::Keyword(Keyword::new_wildcard("filter".to_string()))]),
+                search: Search::And(vec![Search::Keyword(Keyword::new_wildcard(
+                    "filter".to_string()
+                ))]),
                 operators: vec![],
             }
         );
@@ -1002,7 +999,9 @@ mod tests {
             query,
             " *abc* ",
             Query {
-                search: Search::And(vec![Search::Keyword(Keyword::new_wildcard("abc".to_string()))]),
+                search: Search::And(vec![Search::Keyword(Keyword::new_wildcard(
+                    "abc".to_string()
+                ))]),
                 operators: vec![],
             }
         );
@@ -1048,29 +1047,43 @@ mod tests {
             filter_expr,
             "abc OR (def OR xyz)",
             Search::Or(vec![
-                    Search::Keyword(Keyword::new_wildcard("abc".to_string())),
-                    Search::Or(vec![
-                        Search::Keyword(Keyword::new_wildcard("def".to_string())),
-                        Search::Keyword(Keyword::new_wildcard("xyz".to_string()))
-                    ])
+                Search::Keyword(Keyword::new_wildcard("abc".to_string())),
+                Search::Or(vec![
+                    Search::Keyword(Keyword::new_wildcard("def".to_string())),
+                    Search::Keyword(Keyword::new_wildcard("xyz".to_string()))
+                ])
             ])
         );
     }
 
     #[test]
     fn not_filter() {
-        expect!(filter_not, "NOT abc", Search::Not(Box::new(Search::Keyword(Keyword::new_wildcard("abc".to_string())))));
-        expect!(filter_expr, "NOT abc", Search::And(
-            vec![Search::Not(Box::new(Search::Keyword(Keyword::new_wildcard("abc".to_string()))))]
-        ));
-        expect!(filter_expr, "(error OR warn) AND NOT hide",
-               Search::And(vec![
-                   Search::Or(vec![
-                       Search::Keyword(Keyword::new_wildcard("error".to_string())),
-                       Search::Keyword(Keyword::new_wildcard("warn".to_string()))
-                   ]),
-                   Search::Not(Box::new(Search::Keyword(Keyword::new_wildcard("hide".to_string())))),
-               ])
+        expect!(
+            filter_not,
+            "NOT abc",
+            Search::Not(Box::new(Search::Keyword(Keyword::new_wildcard(
+                "abc".to_string()
+            ))))
+        );
+        expect!(
+            filter_expr,
+            "NOT abc",
+            Search::And(vec![Search::Not(Box::new(Search::Keyword(
+                Keyword::new_wildcard("abc".to_string())
+            )))])
+        );
+        expect!(
+            filter_expr,
+            "(error OR warn) AND NOT hide",
+            Search::And(vec![
+                Search::Or(vec![
+                    Search::Keyword(Keyword::new_wildcard("error".to_string())),
+                    Search::Keyword(Keyword::new_wildcard("warn".to_string()))
+                ]),
+                Search::Not(Box::new(Search::Keyword(Keyword::new_wildcard(
+                    "hide".to_string()
+                )))),
+            ])
         );
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -91,6 +91,11 @@ mod integration {
     }
 
     #[test]
+    fn filters() {
+        structured_test(include_str!("structured_tests/filters.toml"));
+    }
+
+    #[test]
     fn sort_order() {
         structured_test(include_str!("structured_tests/sort_order.toml"));
     }

--- a/tests/structured_tests/filters.toml
+++ b/tests/structured_tests/filters.toml
@@ -1,0 +1,14 @@
+query = """(error OR warn) AND NOT hide | count"""
+input = """
+ERROR this is bad
+ERROR
+WARN
+WARN hide
+ERROR hide
+INFO everything is fine
+"""
+output = """
+_count
+--------------
+3
+"""


### PR DESCRIPTION
Supports complex filters like `AND` `OR` and `NOT` re: #68 . Docs coming after.