### PR TITLE
Add logfmt inline operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "im 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "logfmt 0.0.2 (git+https://github.com/brandur/logfmt?tag=v0.0.2)",
  "maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom_locate 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -742,6 +743,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "logfmt"
+version = "0.0.2"
+source = "git+https://github.com/brandur/logfmt?tag=v0.0.2#ee7b87deb117715bb382f03e1b191e57c5071bbf"
 
 [[package]]
 name = "maplit"
@@ -2101,6 +2107,7 @@ dependencies = [
 "checksum libflate 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "bff3ac7d6f23730d3b533c35ed75eef638167634476a499feef16c428d74b57b"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum logfmt 0.0.2 (git+https://github.com/brandur/logfmt?tag=v0.0.2)" = "<none>"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ annotate-snippets = { version = "0.5.0", features = ["ansi_term"] }
 atty = "0.2.0"
 lazy_static = "1.2.0"
 im = "13.0.0"
+logfmt = { git = "https://github.com/brandur/logfmt", tag = "v0.0.2" }
 
 [dev-dependencies]
 assert_cli = "0.6.3"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ Given input like:
 ```
 ![json.gif](/screen_shots/json.gif)
 
+##### Logfmt
+`logfmt [from other_field]`: Extract logfmt-serialized rows into fields for later use. If the row is _not_ valid logfmt, then it is dropped. Optionally, `from other_field` can be specified. Logfmt is a an output format commonly used by Heroku and Splunk, described at https://www.brandur.org/logfmt.
+
+*Examples*:
+```agrind
+* | logfmt
+```
+
+Given input like:
+```
+{"key": "blah", "nested_key": "some=logfmt data=more"}
+```
+```agrind
+* | json | logfmt from nested_key | fields some
+```
+
 ##### Parse
 `parse "* pattern * otherpattern *" [from field] as a,b,c [nodrop]`: Parse text that matches the pattern into variables. Lines that don't match the pattern will be dropped unless `nodrop` is specified. `*` is equivalent to regular expression `.*` and is greedy.
 By default, `parse` operates on the raw text of the message. With `from field_name`, parse will instead process input from a specific column.

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -81,6 +81,9 @@ impl lang::Positioned<lang::InlineOperator> {
             lang::InlineOperator::Json { input_column } => {
                 Ok(Box::new(operator::ParseJson::new(input_column)))
             }
+            lang::InlineOperator::Logfmt { input_column } => {
+                Ok(Box::new(operator::ParseLogfmt::new(input_column)))
+            }
             lang::InlineOperator::Parse {
                 pattern,
                 fields,

--- a/test_files/test_logfmt.log
+++ b/test_files/test_logfmt.log
@@ -1,0 +1,3 @@
+level=info msg="Stopping all fetchers" tag=stopping_fetchers id=ConsumerFetcherManager-1382721708341 module=kafka.consumer.ConsumerFetcherManager
+level=info msg="Starting all fetchers" tag=starting_fetchers id=ConsumerFetcherManager-1382721708342 module=kafka.consumer.ConsumerFetcherManager
+level=warn msg="Fetcher failed to start" tag=errored_fetchers id=ConsumerFetcherManager-1382721708342 module=kafka.consumer.ConsumerFetcherManager

--- a/test_files/test_nested_logfmt.log
+++ b/test_files/test_nested_logfmt.log
@@ -1,0 +1,1 @@
+{"key": "blah", "nested_key": "some=logfmt data=more"}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -75,6 +75,11 @@ mod integration {
     }
 
     #[test]
+    fn logfmt_operator() {
+        structured_test(include_str!("structured_tests/logfmt.toml"));
+    }
+
+    #[test]
     fn sum_operator() {
         structured_test(include_str!("structured_tests/sum.toml"));
     }

--- a/tests/structured_tests/logfmt.toml
+++ b/tests/structured_tests/logfmt.toml
@@ -1,0 +1,11 @@
+query = """* | logfmt | fields thing_a, thing_b"""
+input = """
+thing_a=5 thing_b=red
+thing_a=6 thing_b=yellow
+thing_a=7 thing_b=blue
+"""
+output = """
+[thing_a=5]              [thing_b=red]
+[thing_a=6]              [thing_b=yellow]
+[thing_a=7]              [thing_b=blue]
+"""


### PR DESCRIPTION
Adds an operator for parsing `logfmt` - described at https://www.brandur.org/logfmt - that works similarly to the JSON operator. Logfmt only contains pairs of key/value strings. This work supports `logfmt` and `logfmt from nested_key` syntaxes.

Resolves #74.