### PR TITLE
Add --format|-m argument to specify rendering format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "serde 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.82 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1491,6 +1492,11 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strfmt"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "string"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2197,7 @@ dependencies = [
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b278b244ef7aa5852b277f52dd0c6cac3a109919e1f6d699adde63251227a30f"
 "checksum string 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98998cced76115b1da46f63388b909d118a37ae0be0f82ad35773d4a4bc9d18d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ atty = "0.2.0"
 lazy_static = "1.2.0"
 im = "13.0.0"
 logfmt = { git = "https://github.com/brandur/logfmt", tag = "v0.0.2" }
+strfmt = "0.1.6"
 
 [dev-dependencies]
 assert_cli = "0.6.3"

--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ tail -f live_pcap | agrind '* | parse "* > *:" as src, dest | parse "length *" a
 [dest=111.221.29.254.https]        [length=310]      [src=21:50:18.458527 IP 10.0.2.243.47152]
 ```
 
+Alternate rendering formats can be provided with the `--format` flag. This flag uses the formatting syntax defined in https://doc.rust-lang.org/std/fmt/#syntax. For example
+```
+tail -f live_pcap | agrind --format '{src} => {dst} | length={length}' '* | parse "* > *:" as src, dest | parse "length *" as length'
+21:50:18.458331 IP 10.0.2.243.47152 => 111.221.29.254.https | length=0
+21:50:18.458527 IP 10.0.2.243.47152 => 111.221.29.254.https | length=310
+```
+
 Aggregate data is written to the terminal and will live-update until the stream ends:
 ```noformat
 k2                  avg         

--- a/src/bin/agrind.rs
+++ b/src/bin/agrind.rs
@@ -35,6 +35,11 @@ struct Cli {
     /// Optionally reads from a file instead of Stdin
     #[structopt(long = "file", short = "f")]
     file: Option<String>,
+
+    /// Provide a Rust std::fmt string to format output
+    #[structopt(long = "format", short = "m")]
+    format: Option<String>,
+
     #[structopt(flatten)]
     verbosity: Verbosity,
 }
@@ -73,7 +78,7 @@ fn main() -> CliResult {
         }),
     );
     args.verbosity.setup_env_logger("agrind")?;
-    let pipeline = Pipeline::new(&query)?;
+    let pipeline = Pipeline::new(&query, args.format)?;
     match args.file {
         Some(file_name) => {
             let f = File::open(file_name)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub mod pipeline {
             }
         }
 
-        pub fn new(pipeline: &QueryContainer) -> Result<Self, Error> {
+        pub fn new(pipeline: &QueryContainer, format: Option<String>) -> Result<Self, Error> {
             let parsed = pipeline.parse().map_err(|_pos| CompileError::Parse);
             let query = parsed?;
             let filters = Pipeline::convert_filter(query.search);
@@ -166,6 +166,7 @@ pub mod pipeline {
                         floating_points: 2,
                         min_buffer: 4,
                         max_buffer: 8,
+                        format: format,
                     },
                     Duration::from_millis(50),
                 ),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -311,9 +311,28 @@ None         1")
             .unwrap();
     }
 
+    #[test]
+    fn custom_format() {
+        assert_cli::Assert::main_binary()
+            .with_args(&[
+                "* | logfmt",
+                "--format",
+                "{level} | {msg:<30} module={module}",
+                "--file",
+                "test_files/test_logfmt.log",
+            ])
+            .stdout()
+            .is(
+                "info | Stopping all fetchers          module=kafka.consumer.ConsumerFetcherManager
+info | Starting all fetchers          module=kafka.consumer.ConsumerFetcherManager
+warn | Fetcher failed to start        module=kafka.consumer.ConsumerFetcherManager",
+            )
+            .unwrap();
+    }
+
     fn ensure_parses(query: &str) {
         let query_container = QueryContainer::new(query.to_string(), Box::new(EmptyErrorReporter));
-        Pipeline::new(&query_container).expect(&format!(
+        Pipeline::new(&query_container, None).expect(&format!(
             "Query: `{}` from the README should have parsed",
             query
         ));


### PR DESCRIPTION
This format conforms to https://doc.rust-lang.org/std/fmt, with the
limitations mentioned in https://github.com/vitiral/strfmt.

For example, with a record containing level=info, msg="some string",
org=foo, you can render it with `{level} | {msg:<30} org={org}` to get
```
info | some string                    org=foo
```

Resolves #76.