### PR TITLE
Implement 'split' operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ Given input like:
 ```
 
 ##### Split
-`split [input_field] [with separator] [as new_field]`: Split the input via the separator (default is `,`). Output is an array type. If no `input_field` or `new_field`, the contents will be put in the key `_split`.
+`split [input_field] [on separator] [as new_field]`: Split the input via the separator (default is `,`). Output is an array type. If no `input_field` or `new_field`, the contents will be put in the key `_split`.
 
 *Examples*:
 ```agrind
-* | split with " "
+* | split on " "
 ```
 
 Given input like:
@@ -135,7 +135,7 @@ Other possible usages:
 ```
 
 ```agrind
-* | logfmt | split raw with "blah" as tokens | sum(tokens[1])
+* | logfmt | split raw on "blah" as tokens | sum(tokens[1])
 ```
 
 ##### Parse

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Given input like:
 ```
 
 ##### Split
-`split [input_field] [on separator] [as new_field]`: Split the input via the separator (default is `,`). Output is an array type. If no `input_field` or `new_field`, the contents will be put in the key `_split`.
+`split[(input_field)] [on separator] [as new_field]`: Split the input via the separator (default is `,`). Output is an array type. If no `input_field` or `new_field`, the contents will be put in the key `_split`.
 
 *Examples*:
 ```agrind
@@ -129,13 +129,26 @@ Output:
 [_split=[INFO, web-001, influxd[188053]:, 127.0.0.1, POST /write HTTP/1.0, 204]]
 ```
 
-Other possible usages:
+If `input_field` is used, and there is no `new_field` specified, then the `input_field` will be overridden with the split data-structure. For example:
 ```agrind
-* | parse "* *" as level, csv | split csv | count by csv[2]
+* | parse "* *" as level, csv | split(csv)
 ```
 
+Given input like:
+```
+INFO darren,hello,50
+WARN jonathon,good-bye,100
+```
+
+Will output:
+```
+[csv=[darren, hello, 50]]        [level=INFO]
+[csv=[jonathon, good-bye, 100]]        [level=WARN]
+```
+
+Other examples:
 ```agrind
-* | logfmt | split raw on "blah" as tokens | sum(tokens[1])
+* | logfmt | split(raw) on "blah" as tokens | sum(tokens[1])
 ```
 
 ##### Parse

--- a/src/data.rs
+++ b/src/data.rs
@@ -140,15 +140,16 @@ impl Value {
         }
     }
 
-    pub fn from_string(s: &str) -> Value {
-        let int_value = s.trim().parse::<i64>();
-        let float_value = s.trim().parse::<f64>();
-        let bool_value = s.trim().parse::<bool>();
+    pub fn from_string(s: impl AsRef<str> + Into<String>) -> Value {
+        let trimmed = s.as_ref().trim();
+        let int_value = trimmed.parse::<i64>();
+        let float_value = trimmed.parse::<f64>();
+        let bool_value = trimmed.parse::<bool>();
         int_value
             .map(Value::Int)
             .or_else(|_| float_value.map(Value::from_float))
             .or_else(|_| bool_value.map(Value::Bool))
-            .unwrap_or_else(|_| Value::Str(s.to_string()))
+            .unwrap_or_else(|_| Value::Str(s.into()))
     }
 }
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -486,12 +486,12 @@ macro_rules! verify_ref {
   );
 }
 
-fn expr_not_with_or_as(e: &Expr) -> bool {
+fn expr_not_on_or_as(e: &Expr) -> bool {
     match e {
         Expr::Column {
             head: DataAccessAtom::Key(s),
             rest: _,
-        } => s != "with" && s != "as",
+        } => s != "on" && s != "as",
         _ => false,
     }
 }
@@ -510,9 +510,9 @@ named!(split<Span, Positioned<InlineOperator>>, with_pos!(ws!(do_parse!(
     tag!("split") >>
     from_column_opt: opt!(verify_ref!(
         expr,
-        expr_not_with_or_as
+        expr_not_on_or_as
     )) >>
-    separator_opt: opt!(ws!(preceded!(tag!("with"), quoted_string))) >>
+    separator_opt: opt!(ws!(preceded!(tag!("on"), quoted_string))) >>
     rename_opt: opt!(ws!(preceded!(tag!("as"), ident))) >>
     (InlineOperator::Split {
         separator: separator_opt.map(|s| s.to_string()).unwrap_or_else(|| ",".to_string()),

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -909,10 +909,10 @@ pub struct Split {
 }
 
 impl Split {
-    pub fn new(separator: String, input_column: Option<String>, output_column: String) -> Self {
+    pub fn new(separator: String, input_column: Option<Expr>, output_column: String) -> Self {
         Self {
             separator,
-            input_column: input_column.map(Expr::Column),
+            input_column,
             output_column,
         }
     }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -901,32 +901,7 @@ impl UnaryPreAggOperator for Total {
     }
 }
 
-pub struct SplitDef {
-    separator: String,
-    input_column: Option<String>,
-    output_column: String,
-}
-
-impl SplitDef {
-    pub fn new(separator: String, input_column: Option<String>, output_column: String) -> Self {
-        SplitDef {
-            separator,
-            input_column,
-            output_column,
-        }
-    }
-}
-
-impl OperatorBuilder for SplitDef {
-    fn build(&self) -> Box<dyn UnaryPreAggOperator> {
-        Box::new(Split::new(
-            self.separator.clone(),
-            self.input_column.clone(),
-            self.output_column.clone(),
-        ))
-    }
-}
-
+#[derive(Clone)]
 pub struct Split {
     separator: String,
     input_column: Option<Expr>,
@@ -943,8 +918,8 @@ impl Split {
     }
 }
 
-impl UnaryPreAggOperator for Split {
-    fn process_mut(&mut self, rec: Record) -> Result<Option<Record>, EvalError> {
+impl UnaryPreAggFunction for Split {
+    fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
         let inp = get_input(&rec, &self.input_column)?;
         let array = split::split_with_separator_and_closures(
             &inp,

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -905,11 +905,11 @@ impl UnaryPreAggOperator for Total {
 pub struct Split {
     separator: String,
     input_column: Option<Expr>,
-    output_column: String,
+    output_column: Option<Expr>,
 }
 
 impl Split {
-    pub fn new(separator: String, input_column: Option<Expr>, output_column: String) -> Self {
+    pub fn new(separator: String, input_column: Option<Expr>, output_column: Option<Expr>) -> Self {
         Self {
             separator,
             input_column,
@@ -927,7 +927,11 @@ impl UnaryPreAggFunction for Split {
             &split::DEFAULT_CLOSURES,
             data::Value::from_string,
         );
-        let rec = rec.put(&self.output_column, data::Value::Array(array));
+        let rec = if let Some(output_column) = &self.output_column {
+            rec.put_expr(output_column, data::Value::Array(array))?
+        } else {
+            rec.put("_split", data::Value::Array(array))
+        };
         Ok(Some(rec))
     }
 }

--- a/src/operator/split.rs
+++ b/src/operator/split.rs
@@ -26,14 +26,10 @@ pub fn split_with_separator_and_closures<T>(
 
     // If any tokens are surrounded by closure start / end, then trim.
     let transform = |mut token: String| {
-        let mut trimmed = true;
-        while trimmed {
-            trimmed = false;
-            for (start, end) in closures {
-                if token.starts_with(start) && token.ends_with(end) {
-                    token = token[start.len()..token.len() - end.len()].to_string();
-                    trimmed = true;
-                }
+        for (start, end) in closures {
+            if token.starts_with(start) && token.ends_with(end) {
+                token = token[start.len()..token.len() - end.len()].to_string();
+                break;
             }
         }
 
@@ -132,7 +128,7 @@ mod tests {
                 "ow",
                 &DEFAULT_CLOSURES
             ),
-            vec!["mm", "mow"],
+            vec!["mm", "\"mow\""],
         );
     }
 }

--- a/src/operator/split.rs
+++ b/src/operator/split.rs
@@ -1,0 +1,138 @@
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+lazy_static! {
+    pub static ref DEFAULT_CLOSURES: HashMap<&'static str, &'static str> = {
+        let mut h = HashMap::new();
+        h.insert("\"", "\"");
+        h.insert("'", "'");
+        h
+    };
+}
+
+/// Helper function for splitting a string by a separator, but also
+/// respecting closures (like "double-quoted strings").
+pub fn split_with_separator_and_closures<T>(
+    input: &str,
+    separator: &str,
+    closures: &HashMap<&'static str, &'static str>,
+    map: impl Fn(String) -> T,
+) -> Vec<T> {
+    let input = input.trim();
+
+    let mut prev_index = 0;
+    let mut index = 0;
+    let mut tokens = vec![];
+
+    // If any tokens are surrounded by closure start / end, then trim.
+    let transform = |mut token: String| {
+        let mut trimmed = true;
+        while trimmed {
+            trimmed = false;
+            for (start, end) in closures {
+                if token.starts_with(start) && token.ends_with(end) {
+                    token = token[start.len()..token.len() - end.len()].to_string();
+                    trimmed = true;
+                }
+            }
+        }
+
+        map(token)
+    };
+
+    while index < input.len() {
+        let mut found_separator = false;
+        let remaining = &input[index..];
+        if remaining.starts_with(separator) {
+            found_separator = true;
+        } else {
+            let mut found = false;
+            for (start, end) in closures {
+                if !remaining.starts_with(start) {
+                    continue;
+                }
+
+                if let Some(end_index) = remaining[start.len()..].find(end) {
+                    index += start.len() + end_index + end.len();
+                    found = true;
+                    break;
+                }
+            }
+
+            if !found {
+                index += 1;
+            }
+        }
+
+        if found_separator {
+            if index != prev_index {
+                tokens.push(transform(input[prev_index..index].to_string()));
+            }
+            index += separator.len();
+            prev_index = index;
+        }
+    }
+
+    if index != prev_index {
+        tokens.push(transform(input[prev_index..index].to_string()));
+    }
+
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn split_with_separator_and_closures_string(
+        input: &str,
+        separator: &str,
+        closures: &HashMap<&'static str, &'static str>,
+    ) -> Vec<String> {
+        split_with_separator_and_closures(input, separator, closures, |s| s)
+    }
+
+    #[test]
+    fn split_works() {
+        assert_eq!(
+            split_with_separator_and_closures_string("power hello", " ", &DEFAULT_CLOSURES),
+            vec!["power", "hello"],
+        );
+        assert_eq!(
+            split_with_separator_and_closures_string("morecomplicated", "ecomp", &DEFAULT_CLOSURES),
+            vec!["mor", "licated"],
+        );
+        assert_eq!(
+            split_with_separator_and_closures_string("owmmowmow", "ow", &DEFAULT_CLOSURES),
+            vec!["mm", "m"],
+        );
+    }
+
+    #[test]
+    fn split_with_closures_works() {
+        assert_eq!(
+            split_with_separator_and_closures_string(
+                "power hello \"good bye\"",
+                " ",
+                &DEFAULT_CLOSURES
+            ),
+            vec!["power", "hello", "good bye"],
+        );
+        assert_eq!(
+            split_with_separator_and_closures_string(
+                "more'ecomp'licated",
+                "ecomp",
+                &DEFAULT_CLOSURES
+            ),
+            vec!["more'ecomp'licated"],
+        );
+        assert_eq!(
+            split_with_separator_and_closures_string(
+                "ow\"mm\"ow'\"mow\"'",
+                "ow",
+                &DEFAULT_CLOSURES
+            ),
+            vec!["mm", "mow"],
+        );
+    }
+}

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -203,6 +203,15 @@ impl TypeCheck<Box<dyn operator::OperatorBuilder + Send + Sync>>
             lang::InlineOperator::Limit { count: None } => {
                 Ok(Box::new(operator::LimitDef::new(DEFAULT_LIMIT)))
             }
+            lang::InlineOperator::Split {
+                separator,
+                input_column,
+                output_column,
+            } => Ok(Box::new(operator::SplitDef::new(
+                separator,
+                input_column,
+                output_column,
+            ))),
             lang::InlineOperator::Total {
                 input_column,
                 output_column,

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -209,7 +209,9 @@ impl TypeCheck<Box<dyn operator::OperatorBuilder + Send + Sync>>
                 output_column,
             } => Ok(Box::new(operator::Split::new(
                 separator,
-                input_column,
+                input_column
+                    .map(|e| e.type_check(error_builder))
+                    .transpose()?,
                 output_column,
             ))),
             lang::InlineOperator::Total {

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -212,7 +212,9 @@ impl TypeCheck<Box<dyn operator::OperatorBuilder + Send + Sync>>
                 input_column
                     .map(|e| e.type_check(error_builder))
                     .transpose()?,
-                output_column,
+                output_column
+                    .map(|e| e.type_check(error_builder))
+                    .transpose()?,
             ))),
             lang::InlineOperator::Total {
                 input_column,

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -207,7 +207,7 @@ impl TypeCheck<Box<dyn operator::OperatorBuilder + Send + Sync>>
                 separator,
                 input_column,
                 output_column,
-            } => Ok(Box::new(operator::SplitDef::new(
+            } => Ok(Box::new(operator::Split::new(
                 separator,
                 input_column,
                 output_column,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -145,8 +145,17 @@ mod integration {
         structured_test(include_str!("structured_tests/nested_values_1.toml"));
         structured_test(include_str!("structured_tests/nested_values_2.toml"));
         structured_test(include_str!("structured_tests/nested_values_3.toml"));
-        structured_test(include_str!("structured_tests/nested_values_3.toml"));
-        structured_test(include_str!("structured_tests/nested_values_3.toml"));
+    }
+
+    #[test]
+    fn test_split() {
+        structured_test(include_str!("structured_tests/split_1.toml"));
+        structured_test(include_str!("structured_tests/split_2.toml"));
+        structured_test(include_str!("structured_tests/split_3.toml"));
+        structured_test(include_str!("structured_tests/split_4.toml"));
+        structured_test(include_str!("structured_tests/split_5.toml"));
+        structured_test(include_str!("structured_tests/split_6.toml"));
+        structured_test(include_str!("structured_tests/split_7.toml"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -156,6 +156,7 @@ mod integration {
         structured_test(include_str!("structured_tests/split_5.toml"));
         structured_test(include_str!("structured_tests/split_6.toml"));
         structured_test(include_str!("structured_tests/split_7.toml"));
+        structured_test(include_str!("structured_tests/split_8.toml"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -157,6 +157,8 @@ mod integration {
         structured_test(include_str!("structured_tests/split_6.toml"));
         structured_test(include_str!("structured_tests/split_7.toml"));
         structured_test(include_str!("structured_tests/split_8.toml"));
+        structured_test(include_str!("structured_tests/split_9.toml"));
+        structured_test(include_str!("structured_tests/split_10.toml"));
     }
 
     #[test]

--- a/tests/structured_tests/split_1.toml
+++ b/tests/structured_tests/split_1.toml
@@ -1,4 +1,6 @@
-query = "* | split with \" \""
+query = """
+* | split with " "
+"""
 input = """
 Oct 09 20:22:21 web-001 influxd[188053]: 127.0.0.1 "POST /write \"escaped\" HTTP/1.0" 204
 """

--- a/tests/structured_tests/split_1.toml
+++ b/tests/structured_tests/split_1.toml
@@ -1,9 +1,9 @@
 query = """
 * | split on " "
 """
-input = """
+input = '''
 Oct 09 20:22:21 web-001 influxd[188053]: 127.0.0.1 "POST /write \"escaped\" HTTP/1.0" 204
-"""
-output = """
-[_split=[Oct, 9, 20:22:21, web-001, influxd[188053]:, 127.0.0.1, POST /write "escaped" HTTP/1.0, 204]]
-"""
+'''
+output = '''
+[_split=[Oct, 9, 20:22:21, web-001, influxd[188053]:, 127.0.0.1, POST /write \"escaped\" HTTP/1.0, 204]]
+'''

--- a/tests/structured_tests/split_1.toml
+++ b/tests/structured_tests/split_1.toml
@@ -1,0 +1,7 @@
+query = "* | split with \" \""
+input = """
+Oct 09 20:22:21 web-001 influxd[188053]: 127.0.0.1 "POST /write \"escaped\" HTTP/1.0" 204
+"""
+output = """
+[_split=[Oct, 9, 20:22:21, web-001, influxd[188053]:, 127.0.0.1, POST /write "escaped" HTTP/1.0, 204]]
+"""

--- a/tests/structured_tests/split_1.toml
+++ b/tests/structured_tests/split_1.toml
@@ -1,5 +1,5 @@
 query = """
-* | split with " "
+* | split on " "
 """
 input = """
 Oct 09 20:22:21 web-001 influxd[188053]: 127.0.0.1 "POST /write \"escaped\" HTTP/1.0" 204

--- a/tests/structured_tests/split_10.toml
+++ b/tests/structured_tests/split_10.toml
@@ -1,0 +1,21 @@
+query = """
+* | json | split(level) on "-" as nested.nested.boo
+"""
+input = """
+{"level": "INFO", "nested": { "nested": "invalid" } }
+{"level": "INFO", "nested": { "nested": 10 } }
+{"level": "INFO", "nested": { "nested": {} } }
+{"level": "INFO", "nested": { "nested": [] } }
+{"level": "INFO", "nested": { "nested": {"boo": "foo"} } }
+{"level": "INFO", "nested": { "nested": {"abc": 10} } }
+"""
+output = """
+[level=INFO]         [nested={nested:{boo:[INFO]}}]
+[level=INFO]         [nested={nested:{boo:[INFO]}}]
+[level=INFO]         [nested={nested:{abc:10, boo:[INFO]}}]
+"""
+error = """
+error: Expected object, found invalid
+error: Expected object, found 10
+error: Expected object, found []
+"""

--- a/tests/structured_tests/split_2.toml
+++ b/tests/structured_tests/split_2.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest with '.'
+* | parse "* *" as level, rest | split rest on '.'
 """
 input = """
 INFO name.power.over_9000

--- a/tests/structured_tests/split_2.toml
+++ b/tests/structured_tests/split_2.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest on '.'
+* | parse "* *" as level, rest | split(rest) on '.'
 """
 input = """
 INFO name.power.over_9000

--- a/tests/structured_tests/split_2.toml
+++ b/tests/structured_tests/split_2.toml
@@ -1,0 +1,11 @@
+query = "* | parse \"* *\" as level, rest | split rest with '.'"
+input = """
+INFO name.power.over_9000
+DEBUG pavel.5000.false
+DEBUG darren.10000.true
+"""
+output = """
+[level=INFO]         [rest=[name, power, over_9000]]
+[level=DEBUG]        [rest=[pavel, 5000, false]]
+[level=DEBUG]        [rest=[darren, 10000, true]]
+"""

--- a/tests/structured_tests/split_2.toml
+++ b/tests/structured_tests/split_2.toml
@@ -1,4 +1,6 @@
-query = "* | parse \"* *\" as level, rest | split rest with '.'"
+query = """
+* | parse "* *" as level, rest | split rest with '.'
+"""
 input = """
 INFO name.power.over_9000
 DEBUG pavel.5000.false

--- a/tests/structured_tests/split_3.toml
+++ b/tests/structured_tests/split_3.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest on '...' as new_rest
+* | parse "* *" as level, rest | split(rest) on '...' as new_rest
 """
 input = """
 INFO name...power...over_9000

--- a/tests/structured_tests/split_3.toml
+++ b/tests/structured_tests/split_3.toml
@@ -1,0 +1,11 @@
+query = "* | parse \"* *\" as level, rest | split rest with '...' as new_rest"
+input = """
+INFO name...power...over_9000
+DEBUG pavel5000...false
+DEBUG darren...10000..true
+"""
+output = """
+[level=INFO]         [new_rest=[name, power, over_9000]]        [rest=name...power...over_9000]
+[level=DEBUG]        [new_rest=[pavel5000, false]]              [rest=pavel5000...false]
+[level=DEBUG]        [new_rest=[darren, 10000..true]]           [rest=darren...10000..true]
+"""

--- a/tests/structured_tests/split_3.toml
+++ b/tests/structured_tests/split_3.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest with '...' as new_rest
+* | parse "* *" as level, rest | split rest on '...' as new_rest
 """
 input = """
 INFO name...power...over_9000

--- a/tests/structured_tests/split_3.toml
+++ b/tests/structured_tests/split_3.toml
@@ -1,4 +1,6 @@
-query = "* | parse \"* *\" as level, rest | split rest with '...' as new_rest"
+query = """
+* | parse "* *" as level, rest | split rest with '...' as new_rest
+"""
 input = """
 INFO name...power...over_9000
 DEBUG pavel5000...false

--- a/tests/structured_tests/split_4.toml
+++ b/tests/structured_tests/split_4.toml
@@ -1,4 +1,6 @@
-query = "* | parse \"* *\" as level, rest | split rest with '.' | count by rest[1]"
+query = """
+* | parse "* *" as level, rest | split rest with '.' | count by rest[1]
+"""
 input = """
 INFO name.power.over_9000
 DEBUG pavel.5000.false

--- a/tests/structured_tests/split_4.toml
+++ b/tests/structured_tests/split_4.toml
@@ -1,0 +1,15 @@
+query = "* | parse \"* *\" as level, rest | split rest with '.' | count by rest[1]"
+input = """
+INFO name.power.over_9000
+DEBUG pavel.5000.false
+DEBUG darren..10000.true
+WARN jonathon...400..false
+"""
+output = """
+rest[1]        _count
+-----------------------------
+400            1
+5000           1
+10000          1
+power          1
+"""

--- a/tests/structured_tests/split_4.toml
+++ b/tests/structured_tests/split_4.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest on '.' | count by rest[1]
+* | parse "* *" as level, rest | split(rest) on '.' | count by rest[1]
 """
 input = """
 INFO name.power.over_9000

--- a/tests/structured_tests/split_4.toml
+++ b/tests/structured_tests/split_4.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest with '.' | count by rest[1]
+* | parse "* *" as level, rest | split rest on '.' | count by rest[1]
 """
 input = """
 INFO name.power.over_9000

--- a/tests/structured_tests/split_5.toml
+++ b/tests/structured_tests/split_5.toml
@@ -1,4 +1,6 @@
-query = "* | parse \"* *\" as level, rest | split rest with '.' | sum(rest[1])"
+query = """
+* | parse "* *" as level, rest | split rest with '.' | sum(rest[1])
+"""
 input = """
 INFO name.power.over_9000
 DEBUG pavel.5000.false

--- a/tests/structured_tests/split_5.toml
+++ b/tests/structured_tests/split_5.toml
@@ -1,0 +1,12 @@
+query = "* | parse \"* *\" as level, rest | split rest with '.' | sum(rest[1])"
+input = """
+INFO name.power.over_9000
+DEBUG pavel.5000.false
+DEBUG darren..10000.true
+WARN jonathon...400..false
+"""
+output = """
+_sum
+-------------
+15400
+"""

--- a/tests/structured_tests/split_5.toml
+++ b/tests/structured_tests/split_5.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest on '.' | sum(rest[1])
+* | parse "* *" as level, rest | split(rest) on '.' | sum(rest[1])
 """
 input = """
 INFO name.power.over_9000

--- a/tests/structured_tests/split_5.toml
+++ b/tests/structured_tests/split_5.toml
@@ -1,5 +1,5 @@
 query = """
-* | parse "* *" as level, rest | split rest with '.' | sum(rest[1])
+* | parse "* *" as level, rest | split rest on '.' | sum(rest[1])
 """
 input = """
 INFO name.power.over_9000

--- a/tests/structured_tests/split_6.toml
+++ b/tests/structured_tests/split_6.toml
@@ -1,5 +1,5 @@
 query = """
-* | logfmt | split raw on "blah" as tokens | sum(tokens[-2])
+* | logfmt | split(raw) on "blah" as tokens | sum(tokens[-2])
 """
 input = """
 level=INFO raw="ablah10blahcblah"

--- a/tests/structured_tests/split_6.toml
+++ b/tests/structured_tests/split_6.toml
@@ -1,8 +1,10 @@
-query = "* | logfmt | split raw with \"blah\" as tokens | sum(tokens[1])"
+query = "* | logfmt | split raw with \"blah\" as tokens | sum(tokens[-2])"
 input = """
 level=INFO raw="ablah10blahcblah"
 level=WARN raw="ablahbblahcblah"
 level=DEBUG raw="ablah55.9blahcblah"
+level=DEBUG raw="apple"
+level=TRACE raw="blahb"
 """
 output = """
 _sum

--- a/tests/structured_tests/split_6.toml
+++ b/tests/structured_tests/split_6.toml
@@ -1,0 +1,11 @@
+query = "* | logfmt | split raw with \"blah\" as tokens | sum(tokens[1])"
+input = """
+level=INFO raw="ablah10blahcblah"
+level=WARN raw="ablahbblahcblah"
+level=DEBUG raw="ablah55.9blahcblah"
+"""
+output = """
+_sum
+-------------
+65.90
+"""

--- a/tests/structured_tests/split_6.toml
+++ b/tests/structured_tests/split_6.toml
@@ -1,4 +1,6 @@
-query = "* | logfmt | split raw with \"blah\" as tokens | sum(tokens[-2])"
+query = """
+* | logfmt | split raw with "blah" as tokens | sum(tokens[-2])
+"""
 input = """
 level=INFO raw="ablah10blahcblah"
 level=WARN raw="ablahbblahcblah"

--- a/tests/structured_tests/split_6.toml
+++ b/tests/structured_tests/split_6.toml
@@ -1,5 +1,5 @@
 query = """
-* | logfmt | split raw with "blah" as tokens | sum(tokens[-2])
+* | logfmt | split raw on "blah" as tokens | sum(tokens[-2])
 """
 input = """
 level=INFO raw="ablah10blahcblah"

--- a/tests/structured_tests/split_7.toml
+++ b/tests/structured_tests/split_7.toml
@@ -1,5 +1,5 @@
 query = """
-* | logfmt | split with " "
+* | logfmt | split on " "
 """
 input = """
 level=INFO raw="ablah10blahcblah"

--- a/tests/structured_tests/split_7.toml
+++ b/tests/structured_tests/split_7.toml
@@ -1,4 +1,6 @@
-query = "* | logfmt | split with \" \""
+query = """
+* | logfmt | split with " "
+"""
 input = """
 level=INFO raw="ablah10blahcblah"
 level=WARN raw="ablahbblahcblah"

--- a/tests/structured_tests/split_7.toml
+++ b/tests/structured_tests/split_7.toml
@@ -1,0 +1,11 @@
+query = "* | logfmt | split with \" \""
+input = """
+level=INFO raw="ablah10blahcblah"
+level=WARN raw="ablahbblahcblah"
+level=DEBUG raw="ablah55.9blahcblah"
+"""
+output = """
+[_split=[level=INFO, raw="ablah10blahcblah"]]        [level=INFO]         [raw=ablah10blahcblah]
+[_split=[level=WARN, raw="ablahbblahcblah"]]         [level=WARN]         [raw=ablahbblahcblah]
+[_split=[level=DEBUG, raw="ablah55.9blahcblah"]]     [level=DEBUG]        [raw=ablah55.9blahcblah]
+"""

--- a/tests/structured_tests/split_8.toml
+++ b/tests/structured_tests/split_8.toml
@@ -7,8 +7,8 @@ input = """
 {"level": "DEBUG" }
 """
 output = """
-[level=INFO]         [raw=[a, b, c]]
-[level=WARN]         [raw=[ab, c]]          [hello=world]
+[level=INFO]         [raw={nested:[a, b, c]}]
+[level=WARN]         [raw={foo:bar, nested:[ab, c]}]        [hello=world]
 """
 error = """
 error: No value for key raw

--- a/tests/structured_tests/split_8.toml
+++ b/tests/structured_tests/split_8.toml
@@ -1,5 +1,5 @@
 query = """
-* | json | split raw.nested on "-"
+* | json | split(raw.nested) on "-"
 """
 input = """
 {"level": "INFO", "raw": { "nested": "a---b---c" }}

--- a/tests/structured_tests/split_8.toml
+++ b/tests/structured_tests/split_8.toml
@@ -1,0 +1,15 @@
+query = """
+* | json | split raw.nested on "-"
+"""
+input = """
+{"level": "INFO", "raw": { "nested": "a---b---c" }}
+{"level": "WARN", "raw": { "nested": "ab---c-", "foo": "bar"}, "hello": "world"}
+{"level": "DEBUG" }
+"""
+output = """
+[level=INFO]         [raw=[a, b, c]]
+[level=WARN]         [raw=[ab, c]]          [hello=world]
+"""
+error = """
+error: No value for key raw
+"""

--- a/tests/structured_tests/split_9.toml
+++ b/tests/structured_tests/split_9.toml
@@ -1,0 +1,19 @@
+query = """
+* | json | split(raw.nested) on "-" as oh_boy[0].abc
+"""
+input = """
+{"level": "INFO", "raw": { "nested": "a---b---c" }, "oh_boy": [{"abc": "xyz", "def": "gg"}, 10]}
+{"level": "WARN", "raw": { "nested": "ab---c-", "foo": "bar"}, "hello": "world"}
+{"level": "DEBUG", "oh_boy": [] }
+{"level": "WARN", "raw": { "nested": "a-c" }, "oh_boy": [{"abc": 10}] }
+{"level": "TRACE", "raw": { "nested": "a-c" }, "oh_boy": [] }
+"""
+output = """
+[level=INFO]         [oh_boy=[{abc:[a, b, c], def:gg}, 10]]        [raw={nested:a---b---c}]
+[level=WARN]         [oh_boy=[{abc:[a, c]}]]                       [raw={nested:a-c}]
+"""
+error = """
+error: No value for key oh_boy
+error: No value for key raw
+error: Index 0 out of range
+"""


### PR DESCRIPTION
Splits the input as a data::Value::Array type, parsing each string into
a more specific type if possible. Allows pass in input / output column
as well as separator (default is ',').