### PR TITLE
Fix array off-by-one and add regression test

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -312,7 +312,7 @@ impl EvaluatableBorrowed<data::Value> for Expr {
                             let vec_len: i64 = vec.len().try_into().unwrap();
                             let real_index = if *index < 0 { *index + vec_len } else { *index };
 
-                            if real_index < 0 || real_index > vec_len {
+                            if real_index < 0 || real_index >= vec_len {
                                 return Err(EvalError::IndexOutOfRange { index: *index });
                             }
                             root_record = &vec[real_index as usize];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -141,6 +141,11 @@ mod integration {
     }
 
     #[test]
+    fn test_json_arrays() {
+        structured_test(include_str!("structured_tests/arrays_1.toml"));
+    }
+
+    #[test]
     fn test_nested_values() {
         structured_test(include_str!("structured_tests/nested_values_1.toml"));
         structured_test(include_str!("structured_tests/nested_values_2.toml"));

--- a/tests/structured_tests/arrays_1.toml
+++ b/tests/structured_tests/arrays_1.toml
@@ -1,0 +1,15 @@
+query = """* | json | sum(thing_a[0])"""
+input = """
+{"thing_a": [0, 1, 2]}
+{"thing_a": [5]}
+{"thing_a": []}
+{}
+{"thing_a": ["foo"]}
+"""
+output = """
+_sum
+------------
+5
+"""
+error = """
+"""


### PR DESCRIPTION
Found this bug when making `put_expr` which uses similar logic.