### PR TITLE
Some refactorings of the split function

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1047,7 +1047,7 @@ impl UnaryPreAggFunction for ParseLogfmt {
             logfmt::parse(&inp.trim_end())
         };
         let res = {
-            pairs.into_iter().fold(rec, |record, pair| match &pair.val {
+            pairs.into_iter().fold(rec, |record, pair| match pair.val {
                 None => record.put(&pair.key, data::Value::None),
                 Some(val) => record.put(&pair.key, data::Value::from_string(val)),
             })

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -925,8 +925,7 @@ impl UnaryPreAggFunction for Split {
             &inp,
             &self.separator,
             &split::DEFAULT_CLOSURES,
-            data::Value::from_string,
-        );
+        ).into_iter().map(data::Value::from_string).collect();
         let rec = if let Some(output_column) = &self.output_column {
             rec.put_expr(output_column, data::Value::Array(array))?
         } else {

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -921,14 +921,10 @@ impl Split {
 impl UnaryPreAggFunction for Split {
     fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
         let inp = get_input(&rec, &self.input_column)?;
-        let array = split::split_with_separator_and_closures(
-            &inp,
-            &self.separator,
-            &split::DEFAULT_CLOSURES,
-        )
-        .into_iter()
-        .map(data::Value::from_string)
-        .collect();
+        let array = split::split_with_delimiters(&inp, &self.separator, &split::DEFAULT_DELIMITERS)
+            .into_iter()
+            .map(data::Value::from_string)
+            .collect();
         let rec = if let Some(output_column) = &self.output_column {
             rec.put_expr(output_column, data::Value::Array(array))?
         } else {

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -925,7 +925,10 @@ impl UnaryPreAggFunction for Split {
             &inp,
             &self.separator,
             &split::DEFAULT_CLOSURES,
-        ).into_iter().map(data::Value::from_string).collect();
+        )
+        .into_iter()
+        .map(data::Value::from_string)
+        .collect();
         let rec = if let Some(output_column) = &self.output_column {
             rec.put_expr(output_column, data::Value::Array(array))?
         } else {

--- a/src/operator/split.rs
+++ b/src/operator/split.rs
@@ -12,12 +12,11 @@ lazy_static! {
 
 /// Helper function for splitting a string by a separator, but also
 /// respecting closures (like "double-quoted strings").
-pub fn split_with_separator_and_closures<T>(
+pub fn split_with_separator_and_closures(
     input: &str,
     separator: &str,
     closures: &HashMap<&'static str, &'static str>,
-    map: impl Fn(String) -> T,
-) -> Vec<T> {
+) -> Vec<String> {
     let input = input.trim();
 
     let mut prev_index = 0;
@@ -32,8 +31,7 @@ pub fn split_with_separator_and_closures<T>(
                 break;
             }
         }
-
-        map(token)
+        token
     };
 
     while index < input.len() {
@@ -85,7 +83,7 @@ mod tests {
         separator: &str,
         closures: &HashMap<&'static str, &'static str>,
     ) -> Vec<String> {
-        split_with_separator_and_closures(input, separator, closures, |s| s)
+        split_with_separator_and_closures(input, separator, closures)
     }
 
     #[test]

--- a/src/operator/split.rs
+++ b/src/operator/split.rs
@@ -53,18 +53,15 @@ pub fn split_with_delimiters<'a>(
             continue;
         }
         // Look for a leading quote
-        let terminator = delimiters
-            .into_iter()
-            .flat_map(|(k, v)| {
-                if wip.starts_with(k) {
-                    Some((k, v))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+        let mut terminator = delimiters.into_iter().flat_map(|(k, v)| {
+            if wip.starts_with(k) {
+                Some((k, v))
+            } else {
+                None
+            }
+        });
 
-        if let Some((term_start, term_end)) = terminator.first() {
+        if let Some((term_start, term_end)) = terminator.next() {
             // If we're left with a quoted string, consume it.
             let (quoted_section, rest) = find_close_terminator(wip, *term_start, *term_end);
             wip = rest;

--- a/src/operator/split.rs
+++ b/src/operator/split.rs
@@ -22,6 +22,8 @@ fn find_close_terminator(s: &str, term: &str) -> Option<usize> {
     return None;
 }
 
+// TODO: this function can be further improved by using `.split` instead of .find, removing a lot of
+// finicky index management
 pub fn split_with_separator_and_closures<'a>(
     input: &'a str,
     separator: &'a str,


### PR DESCRIPTION
Some improvements to the split function:
- It now returns &str and is copy free, which should result in modest performance gains
- Simplified algorithm without any direct index manipulation
- Handling of escaped quotes is now explicit -- I think there were certain cases in the old code where escaped quotes would be handled like regular quotes and end
- `map` functionality removed and refactored into caller
- `closure` renamed to `delimiter` which is a more typical verbiage and doesn't overlap with "closure" which typically means the scope captured by an anonymous function

cc @DarrenTsung 