### PR TITLE
Trim whitespace from string data

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -155,7 +155,7 @@ impl Value {
             .map(Value::Int)
             .or_else(|_| float_value.map(Value::from_float))
             .or_else(|_| bool_value.map(Value::Bool))
-            .unwrap_or_else(|_| Value::Str(s.into()))
+            .unwrap_or_else(|_| Value::Str(trimmed.into()))
     }
 }
 
@@ -367,6 +367,7 @@ mod tests {
             Value::Str("not a number".to_string())
         );
         assert_eq!(Value::from_string("1 "), Value::Int(1));
+        assert_eq!(Value::from_string("abcd "), Value::Str("abcd".to_owned()));
     }
 
     #[test]

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1284,8 +1284,7 @@ mod tests {
 
     #[test]
     fn query_operators() {
-        let query_str =
-            r#"* | json from col | parse "!123*" as foo | count by foo, foo == 123 | sort by foo dsc "#;
+        let query_str = r#"* | json from col | parse "!123*" as foo | count by foo, foo == 123 | sort by foo dsc "#;
         expect!(
             query,
             query_str,

--- a/src/operator/split.rs
+++ b/src/operator/split.rs
@@ -112,8 +112,21 @@ mod tests {
             vec!["mm", "m"],
         );
         assert_eq!(
-            split_with_delimiters(r#"Oct 09 20:22:21 web-001 influxd[188053]: 127.0.0.1 "POST /write \"escaped\" HTTP/1.0" 204"#, " ", &DEFAULT_DELIMITERS),
-            vec!["Oct", "09", "20:22:21", "web-001", "influxd[188053]:", "127.0.0.1", "POST /write \\\"escaped\\\" HTTP/1.0", "204"],
+            split_with_delimiters(
+                r#"Oct 09 20:22:21 web-001 influxd[188053]: 127.0.0.1 "POST /write \"escaped\" HTTP/1.0" 204"#,
+                " ",
+                &DEFAULT_DELIMITERS
+            ),
+            vec![
+                "Oct",
+                "09",
+                "20:22:21",
+                "web-001",
+                "influxd[188053]:",
+                "127.0.0.1",
+                "POST /write \\\"escaped\\\" HTTP/1.0",
+                "204"
+            ],
         );
     }
 


### PR DESCRIPTION
Using the parse operator can be a bit annoying when dealing with whitespace because of the way it treats spaces. This change simply strips whitespace out when we convert into `Data::*`