### PR TITLE
cargo: bump terminal_size to resolve E0308 unexpected u32 type error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "strfmt 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "terminal_size 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "terminal_size 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2540,7 +2540,7 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "adc4587ead41bf016f11af03e55a624c06568b5a19db4e90fde573d805074f83"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-"checksum terminal_size 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "e25a60e3024df9029a414be05f46318a77c22538861a22170077d0388c0e926e"
+"checksum terminal_size 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
 "checksum termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ nom_locate = { version = "0.3.1", features = ["verbose-errors"] }
 strsim = "0.8.0"
 quicli = "0.4.0"
 regex = "1.1.0"
-terminal_size = "0.1.8"
+terminal_size = "0.1.12"
 quantiles = "0.7.1"
 crossbeam-channel = "0.3.4"
 ordered-float = "1.0.1"


### PR DESCRIPTION
with this patch, ag compiles cleanly on FreeBSD amd64. Once I've tested x86 (32 bit) I will commit it as a new port https://reviews.freebsd.org/D25003

If this update compiles safely on other platforms, can you merge it?

```
...
Compiling terminal_size v0.1.10
error[E0308]: mismatched types
  --> /home/dch/.cargo/registry/src/github.com-1ecc6299db9ec823/terminal_size-0.1.10/src/unix.rs:31:27
   |
31 |     if unsafe { ioctl(fd, TIOCGWINSZ, &mut winsize) } == -1 {
   |                           ^^^^^^^^^^
   |                           |
   |                           expected `u64`, found `u32`
   |                           help: you can convert an `u32` to `u64`: `TIOCGWINSZ.into()`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `terminal_size`.
```

