### PR TITLE
2 small performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "im 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "include_dir 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "logfmt 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -560,6 +561,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fs_extra"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +884,25 @@ dependencies = [
 name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "js-sys"
@@ -2421,6 +2446,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
@@ -2453,6 +2479,8 @@ dependencies = [
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+"checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 "checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ extended-description = """Angle-grinder allows you to parse, aggregate, sum, ave
                         Angle grinder is a bare bones functional programming language coupled with a pretty terminal UI."""
 
 [dependencies]
+jemallocator = "0.3.2"
 serde_json = "1.0.33"
 itertools = "0.8.0"
 nom = { version = "4.2.3", features = ["verbose-errors"] }
@@ -54,7 +55,7 @@ test-generator = "0.3.0"
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = true
-features = ["precommit-hook", "run-cargo-fmt"]
+features = ["run-cargo-fmt", "precommit-hook"]
 
 [[bench]]
 name = "e2e"

--- a/src/bin/agrind.rs
+++ b/src/bin/agrind.rs
@@ -11,6 +11,9 @@ use std::io;
 use std::io::{stdout, BufReader};
 use structopt::StructOpt;
 
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use crate::InvalidArgs::{CantSupplyBoth, InvalidFormatString, InvalidOutputMode};
 use structopt::clap::ArgGroup;
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -320,8 +320,7 @@ impl Record {
                         }
                     }
                 }
-
-                std::mem::replace(root_record, value);
+                *root_record = value;
             }
             // These should not happen, if so this is a programming error
             // since the data cannot be indexed by BoolUnary / Comparison / Value Exprs.

--- a/src/data.rs
+++ b/src/data.rs
@@ -239,10 +239,10 @@ impl Aggregate {
             });
         });
         let raw_data: Vec<HashMap<String, Value>> = data
-            .iter()
-            .map(|&(ref keycols, ref value)| {
+            .into_iter()
+            .map(|(keycols, value)| {
                 let mut new_map: HashMap<String, Value> = keycols
-                    .iter()
+                    .into_iter()
                     .map(|(keycol, val)| (keycol.clone(), Value::Str(val.clone())))
                     .collect();
                 new_map.insert(agg_column.clone(), value.clone());
@@ -260,8 +260,8 @@ impl Aggregate {
 }
 
 impl Record {
-    pub fn put(mut self, key: &str, value: Value) -> Record {
-        self.data.insert(key.to_string(), value);
+    pub fn put<T: Into<String>>(mut self, key: T, value: Value) -> Record {
+        self.data.insert(key.into(), value);
         self
     }
 
@@ -347,10 +347,10 @@ impl Record {
         Ok(self)
     }
 
-    pub fn new(raw: &str) -> Record {
+    pub fn new<T: Into<String>>(raw: T) -> Record {
         Record {
             data: HashMap::new(),
-            raw: raw.to_string(),
+            raw: raw.into(),
         }
     }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1020,9 +1020,12 @@ impl UnaryPreAggFunction for ParseJson {
             })?
         };
         let res = match json {
-            JsonValue::Object(map) => map
-                .into_iter()
-                .fold(rec, |record, (k, v)| record.put(k, json_to_value(v))),
+            JsonValue::Object(map) => {
+                let mut rec = rec;
+                rec.data.reserve(map.len());
+                map.into_iter()
+                    .fold(rec, |record, (k, v)| record.put(k, json_to_value(v)))
+            }
             // TODO: we'll implicitly drop non-object root values. Maybe we should produce an EvalError here
             _other => rec,
         };

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -988,27 +988,29 @@ impl ParseJson {
 
 impl UnaryPreAggFunction for ParseJson {
     fn process(&self, rec: Record) -> Result<Option<Record>, EvalError> {
-        fn json_to_value(v: &JsonValue) -> data::Value {
-            match *v {
-                JsonValue::Number(ref num) => {
+        fn json_to_value(v: JsonValue) -> data::Value {
+            match v {
+                JsonValue::Number(num) => {
                     if num.is_i64() {
                         data::Value::Int(num.as_i64().unwrap())
                     } else {
                         data::Value::from_float(num.as_f64().unwrap())
                     }
                 }
-                JsonValue::String(ref s) => data::Value::Str(s.to_string()),
+                JsonValue::String(s) => data::Value::Str(s),
                 JsonValue::Null => data::Value::None,
                 JsonValue::Bool(b) => data::Value::Bool(b),
-                JsonValue::Object(ref map) => data::Value::Obj(
-                    map.iter()
+                JsonValue::Object(map) => data::Value::Obj(
+                    map.into_iter()
                         .map(|(k, v)| (k.to_string(), json_to_value(v)))
                         .collect::<HashMap<String, data::Value>>()
                         .into(),
                 ),
-                JsonValue::Array(ref vec) => {
-                    data::Value::Array(vec.iter().map(json_to_value).collect::<Vec<data::Value>>())
-                }
+                JsonValue::Array(vec) => data::Value::Array(
+                    vec.into_iter()
+                        .map(json_to_value)
+                        .collect::<Vec<data::Value>>(),
+                ),
             }
         };
         let json: JsonValue = {
@@ -1019,7 +1021,7 @@ impl UnaryPreAggFunction for ParseJson {
         };
         let res = match json {
             JsonValue::Object(map) => map
-                .iter()
+                .into_iter()
                 .fold(rec, |record, (k, v)| record.put(k, json_to_value(v))),
             // TODO: we'll implicitly drop non-object root values. Maybe we should produce an EvalError here
             _other => rec,


### PR DESCRIPTION
- use jemalloc -- this makes a huge difference because objects are being dropped on a different thread than they were created on which makes the regular allocator very sad
- avoid clones in Json