### PR TITLE
[lang] Support sorting on arbitrary expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,11 +335,21 @@ Count number of source_hosts:
 ```
 
 ##### Sort
-`sort by a, [b, c] [asc|desc]`: Sort aggregate data by a collection of columns. Defaults to ascending.
+`sort by a, [b, c] [asc|desc]`: Sort aggregate data by a collection of columns. Defaults to ascending. 
 
 *Examples*:
 ```agrind
 * | json | count by endpoint_url, status_code | sort by endpoint_url desc
+```
+
+In addition to columns, `sort` can also sort an arbitrary expressions.
+```agrind
+* | json | sort by num_requests / num_responses
+```
+
+
+```agrind
+* | json | sort by length(endpoint_url)
 ```
 
 ##### Total

--- a/tests/structured_tests/sort_by_expr.toml
+++ b/tests/structured_tests/sort_by_expr.toml
@@ -1,0 +1,21 @@
+query = "* | json | sort  by length(message), num_things.k"
+input = """
+{"level": "info", "message": "A thing", "num_things": { "k": 1102} }
+{"level": "info", "message": "A thing", "num_things": { "k": 1103} }
+{"level": "info", "message": "A thing ha", "num_things": 2}
+{"level": "info", "message": "A different", "num_things": 2.000001}
+{"level": "info", "message": "A different e", "num_things": 0.2000001}
+{"level": "info", "message": "A different ev", "num_things": "whoops not a number"}
+{"level": null}
+"""
+output = """
+level        message              num_things
+-------------------------------------------------------------
+info         A thing              {k:1102}
+info         A thing              {k:1103}
+info         A thing ha           2
+info         A different          2.00
+info         A different e        0.20
+info         A different ev       whoops not a number
+None         None                 None
+"""


### PR DESCRIPTION
Previously, you could only sort on a named column. This posed problems
if you wanted to sort on a key in nested JSON structure especially --
now you can sort on anything, whether or not it's a named column.