### PR TITLE
[lang] Support conditional counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ In the simplest form, key fields refer to columns, but they can also be generali
 There are several aggregate operators available.
 
 ##### Count
-`count[(condition)] [as count_column]`: Counts the number of input rows. Output column Defaults to `_count`. Optionally, you
+`count[(condition)] [as count_column]`: Counts the number of input rows. Output column defaults to `_count`. Optionally, you
 can provide a condition -- this will count all rows for which the condition evaluates to true.
 
 *Examples*:

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ In the simplest form, key fields refer to columns, but they can also be generali
 There are several aggregate operators available.
 
 ##### Count
-`count [as count_column]`: Counts the numer of input rows. Output column Defaults to `_count`
+`count[(condition)] [as count_column]`: Counts the number of input rows. Output column Defaults to `_count`. Optionally, you
+can provide a condition -- this will count all rows for which the condition evaluates to true.
 
 *Examples*:
 
@@ -293,6 +294,11 @@ Count number of rows by `source_host`:
 Count number of source_hosts:
 ```agrind
 * | count by source_host | count
+```
+
+Count the number of info vs. error logs:
+```agrind
+* | json | count(level == "info") as info_logs, count(level == "error") as error_logs
 ```
 
 ##### Sum

--- a/aliases/multi-operator.toml
+++ b/aliases/multi-operator.toml
@@ -1,4 +1,4 @@
 keyword = "testmultioperator"
 template = """
-json | count(abc)
+json | count
 """

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -445,7 +445,7 @@ pub struct Count<T> {
 }
 
 impl<T> Count<T> {
-    pub fn new_with_condition(condition: Option<T>) -> Count<T> {
+    pub fn new(condition: Option<T>) -> Count<T> {
         Count {
             count: 0,
             condition,
@@ -470,7 +470,7 @@ impl<T: 'static + Send + Sync + Evaluatable<bool>> AggregateFunction for Count<T
     }
 
     fn empty_box(&self) -> Box<dyn AggregateFunction> {
-        Box::new(Count::new_with_condition(self.condition.clone()))
+        Box::new(Count::new(self.condition.clone()))
     }
 }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -439,19 +439,29 @@ impl Evaluatable<String> for Expr {
 }
 
 #[derive(Default)]
-pub struct Count {
+pub struct Count<T> {
     count: i64,
+    condition: Option<T>,
 }
 
-impl Count {
-    pub fn new() -> Count {
-        Count { count: 0 }
+impl<T> Count<T> {
+    pub fn new_with_condition(condition: Option<T>) -> Count<T> {
+        Count {
+            count: 0,
+            condition,
+        }
     }
 }
 
-impl AggregateFunction for Count {
-    fn process(&mut self, _rec: &Data) -> Result<(), EvalError> {
-        self.count += 1;
+impl<T: 'static + Send + Sync + Evaluatable<bool>> AggregateFunction for Count<T> {
+    fn process(&mut self, data: &Data) -> Result<(), EvalError> {
+        let count_record = match &self.condition {
+            Some(cond) => cond.eval(data)?,
+            None => true,
+        };
+        if count_record {
+            self.count += 1;
+        }
         Ok(())
     }
 
@@ -460,7 +470,7 @@ impl AggregateFunction for Count {
     }
 
     fn empty_box(&self) -> Box<dyn AggregateFunction> {
-        Box::new(Count::new())
+        Box::new(Count::new_with_condition(self.condition.clone()))
     }
 }
 
@@ -1241,6 +1251,15 @@ mod tests {
         }
     }
 
+    impl Count<Expr> {
+        pub fn unconditional() -> Count<Expr> {
+            Count {
+                count: 0,
+                condition: None,
+            }
+        }
+    }
+
     #[test]
     fn test_nested_eval() {
         let rec = Record::new(
@@ -1493,7 +1512,7 @@ mod tests {
     #[test]
     fn count_no_groups() {
         let ops: Vec<(String, Box<dyn AggregateFunction>)> =
-            vec![("_count".to_string(), Box::new(Count::new()))];
+            vec![("_count".to_string(), Box::new(Count::unconditional()))];
         let mut count_agg = MultiGrouper::new(&[], vec![], ops);
         (0..10)
             .map(|n| Record::new(&n.to_string()))
@@ -1516,7 +1535,7 @@ mod tests {
     #[test]
     fn multi_grouper() {
         let ops: Vec<(String, Box<dyn AggregateFunction>)> = vec![
-            ("_count".to_string(), Box::new(Count::new())),
+            ("_count".to_string(), Box::new(Count::unconditional())),
             ("_sum".to_string(), Box::new(Sum::empty("v1"))),
             ("_min".to_string(), Box::new(Min::empty("v1"))),
             ("_max".to_string(), Box::new(Max::empty("v1"))),
@@ -1589,7 +1608,7 @@ mod tests {
     #[test]
     fn count_groups() {
         let ops: Vec<(String, Box<dyn AggregateFunction>)> =
-            vec![("_count".to_string(), Box::new(Count::new()))];
+            vec![("_count".to_string(), Box::new(Count::unconditional()))];
         let mut count_agg = MultiGrouper::new(&[Expr::column("k1")], vec!["k1".to_string()], ops);
         (0..10).for_each(|n| {
             let rec = Record::new(&n.to_string());

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -298,7 +298,10 @@ impl TypeCheck<Box<dyn operator::AggregateFunction>> for lang::Positioned<lang::
         error_builder: &T,
     ) -> Result<Box<dyn operator::AggregateFunction>, TypeError> {
         match self.value {
-            lang::AggregateFunction::Count => Ok(Box::new(operator::Count::new())),
+            lang::AggregateFunction::Count { condition } => {
+                let expr = condition.map(|c| c.type_check(error_builder)).transpose()?;
+                Ok(Box::new(operator::Count::new_with_condition(expr)))
+            }
             lang::AggregateFunction::Min { column } => Ok(Box::new(operator::Min::empty(
                 column.type_check(error_builder)?,
             ))),

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -300,7 +300,7 @@ impl TypeCheck<Box<dyn operator::AggregateFunction>> for lang::Positioned<lang::
         match self.value {
             lang::AggregateFunction::Count { condition } => {
                 let expr = condition.map(|c| c.type_check(error_builder)).transpose()?;
-                Ok(Box::new(operator::Count::new_with_condition(expr)))
+                Ok(Box::new(operator::Count::new(expr)))
             }
             lang::AggregateFunction::Min { column } => Ok(Box::new(operator::Min::empty(
                 column.type_check(error_builder)?,

--- a/tests/structured_tests/count_condtional.toml
+++ b/tests/structured_tests/count_condtional.toml
@@ -1,0 +1,14 @@
+query = """* | json | count(level == "error") as num_errors, count(level == "info") as num_info"""
+input = """
+{"level": "info", "message": "A thing happened", "num_things": 1102}
+{"level": "error", "message": "Oh now an error!"}
+{"level": "error", "message": "So many more errors!"}
+{"level": "info", "message": "A thing happened", "num_things": 12}
+{"level": "info", "message": "A different event", "event_duration": 1002.5}
+{"level": null}
+"""
+output = """
+num_errors        num_info
+----------------------------------
+2                 3
+"""


### PR DESCRIPTION
I've wished I could do this forever! You can now `count(condition) as
xyz` to count _only_ rows that match by condition. The previous
alternative was `count by condition`, eg `count by x > 500`, but that
generates multiple rows and is harder to read. We should add transpose
at some point -- there are times when it's required, but this should
allow solving a lot of the use cases for transpose more intuitively.

cc @tstack I changed `count_frequent` to `count_distinct` in the language in one spot. I think that's what you meant.