### PR TITLE
[lang] Add escape syntax for field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ A simple query that operates on JSON logs and counts the number of logs per leve
 agrind '* | json | count by log_level'
 ```
 
+### Escaping Field Names
+
+Field names containing spaces, periods, or quotes must be escaped using `["<FIELD>"]`:
+
+```bash
+agrind '* | json | count by ["date received"], ["grpc.method"]
+```
+
 ### Filters
 
 There are three basic filters:

--- a/tests/structured_tests/escaped_ident.toml
+++ b/tests/structured_tests/escaped_ident.toml
@@ -1,0 +1,13 @@
+query = """
+* | json | count by ["grpc.method"], ["start time"], nested.["user.name"]
+"""
+input = """
+{"start time": "today", "grpc.method": "Foo", "nested": {"user.name": "user1"}}
+{"start time": "today", "grpc.method": "Bar", "nested": {"user.name": "user1"}}
+"""
+output = """
+["grpc.method"]        ["start time"]        nested.["user.name"]        _count
+---------------------------------------------------------------------------------------
+Bar                    today                 user1                       1
+Foo                    today                 user1                       1
+"""


### PR DESCRIPTION
Related to https://github.com/rcoh/angle-grinder/issues/99

Currently field names containing a space or period, e.g. `date received` or `grpc.method`, cannot be parsed. This could be worked around using `jq` or similar tools to rewrite the field name, but that's a pain.

This commit adds an escaped field name syntax of `["<FIELD>"]`. This is based on the [Object Identifier-Index syntax](https://stedolan.github.io/jq/manual/#ObjectIdentifier-Index:.foo,.foo.bar) used by `jq`, so it should be somewhat familiar to many people who parse JSON on the command line.

The more obvious option of delimiting with just quotes, e.g. "date received", creates an ambiguity between string literals and escaped field names. For example, does `where foo == "date received"` mean field `foo` matches field `date received`, or field `foo` matches the string "date received"?

**Example query**:

```bash
agrind '* | json | where ["grpc.method"] == "Foo" | count by ["date received"]'
```