### PR TITLE
[lang] support regex option for parse operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,28 @@ expression will match _any_ whitespace character in the input text (eg. a litera
 ```
 ![parse.gif](/screen_shots/parse.gif)
 
+##### Parse Regex
+`parse regex "<regex-with-named-captures>" [from field] [nodrop]`: Match the
+input text against a regular expression and populate the record with the named
+captures.  Lines that don't match the pattern will be dropped unless `nodrop` is
+specified. By default, `parse` operates on the raw text of the message. With
+`from field_name`, parse will instead process input from a specific column.
+
+*Notes*:
+
+- Only named captures are supported.  If the regular expression includes any
+  unnamed captures, an error will be raised.
+- The [Rust regular expression syntax](https://docs.rs/regex/latest/regex/#syntax) is used.
+- Escape sequences do not require an extra backslash (i.e. `\w` works as-is).
+
+*Examples*:
+To parse the phrase "Hello, ...!" and capture the value of the "..." in the
+name field:
+
+```agrind
+* | parse regex "Hello, (?P<name>\w+)"
+```
+
 ##### Fields
 `fields [only|except|-|+] a, b`: Drop fields `a, b` or include only `a, b` depending on specified mode.
 

--- a/tests/structured_tests/parse_regex.toml
+++ b/tests/structured_tests/parse_regex.toml
@@ -1,4 +1,4 @@
-query = """db-1 response | parse regex "in (?P<duration>\\\\d+)ms" """
+query = 'db-1 response | parse regex "in (?P<duration>\d+)ms"'
 input = """
 INFO Server db-1 loaded response in 500ms
 INFO Server db-2 loaded response in 394ms

--- a/tests/structured_tests/parse_regex.toml
+++ b/tests/structured_tests/parse_regex.toml
@@ -1,0 +1,29 @@
+query = """db-1 response | parse regex "in (?P<duration>\\\\d+)ms" """
+input = """
+INFO Server db-1 loaded response in 500ms
+INFO Server db-2 loaded response in 394ms
+INFO Server db-1 loaded request in 394ms
+WARN Server failed to load response
+INFO Server db-1 loaded response in 100ms
+INFO Server db-1 loaded response in 102ms
+INFO Server db-1 loaded response in 102ms
+INFO Server db-3 loaded response in 103ms
+INFO Server db-1 loaded response in 100ms
+INFO Server db-3 loaded response in 109ms
+INFO Server db-1 loaded response in 100ms
+INFO Server db-3 loaded response in 104ms
+INFO Server db-1 loaded response in 100ms
+INFO Server db-3 loaded response in 100ms
+INFO Server db-1 loaded response in 122ms
+INFO Server db-2 loaded response in 119ms
+"""
+output = """
+[duration=500]
+[duration=100]
+[duration=102]
+[duration=102]
+[duration=100]
+[duration=100]
+[duration=100]
+[duration=122]
+"""


### PR DESCRIPTION
This change adds support for `parse regex`.  It also fixes handling of escape sequences in quoted strings since they weren't really working before.