### PR TITLE
[lang] raise an error if percentile is out-of-range and fix default name

### DIFF
--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -398,6 +398,7 @@ impl TypeCheck<Box<dyn operator::AggregateFunction>> for lang::Positioned<lang::
 
                 Err(TypeError::ExpectedExpr)
             }
+            lang::AggregateFunction::Error => unreachable!(),
         }
     }
 }

--- a/tests/structured_tests/percentile_1.toml
+++ b/tests/structured_tests/percentile_1.toml
@@ -1,0 +1,20 @@
+query = "* | json | p10(num_things), p90(num_things)"
+input = """
+{"level": "info", "num_things": 100}
+{"level": "info", "num_things": 200}
+{"level": "info", "num_things": 100}
+{"level": "info", "num_things": 10}
+{"level": "info", "num_things": 50}
+{"level": "info", "num_things": 105}
+{"level": "info", "num_things": 1000}
+{"level": "info", "num_things": 1100}
+{"level": "info", "num_things": 150}
+{"level": "info", "num_things": 175}
+"""
+output = """
+p10        p90
+-----------------------
+10         1000
+"""
+error = """
+"""


### PR DESCRIPTION
The percentile parser was not enforcing the range and I had
messed up the default_name() case for percentile while
upgrading nom.  A test for percentile has also been added.