### PR TITLE
Use Cow to remove need for cloning input

### DIFF
--- a/benches/e2e.rs
+++ b/benches/e2e.rs
@@ -38,8 +38,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             file: "benches/10k.inp".to_owned(),
         },
         E2eTest {
-            name: "star-count".to_owned(),
-            query: "* | count".to_owned(),
+            name: "star-parse-count".to_owned(),
+            query: "* | parse '*' as k | count by k".to_owned(),
             file: "benches/10k.inp".to_owned(),
         },
         E2eTest {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,4 @@
-use crate::operator::{EvalError, Evaluatable, Expr, ValueRef};
+use crate::operator::{EvalError, Expr, ValueRef};
 use chrono::{DateTime, Duration, Utc};
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
@@ -546,8 +546,8 @@ impl Record {
         let columns: Vec<Expr> = columns.into_iter().map(Into::into).collect();
         move |rec_l: &VMap, rec_r: &VMap| {
             for col in &columns {
-                let l_val: Value = col.eval(rec_l)?;
-                let r_val: Value = col.eval(rec_r)?;
+                let l_val = col.eval_value(rec_l)?;
+                let r_val = col.eval_value(rec_r)?;
                 let cmp = l_val.cmp(&r_val);
                 if cmp != Ordering::Equal {
                     return Ok(cmp);


### PR DESCRIPTION
introduce `Cow<str>` for get_input and follow a few of the consequences. This massively reduces the amount of clones during hot functions in the query pipeline, leading to a 10% increase in performance in most cases.