### PR TITLE
Switch to tikv-jemallocator from jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,6 @@ dependencies = [
  "im",
  "include_dir",
  "itertools 0.8.2",
- "jemallocator",
  "lazy_static",
  "logfmt",
  "maplit",
@@ -57,6 +56,7 @@ dependencies = [
  "structopt",
  "terminal_size",
  "test-generator",
+ "tikv-jemallocator",
  "toml 0.4.10",
 ]
 
@@ -1052,27 +1052,6 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "joinery"
@@ -2169,6 +2148,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.3+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 self-update = ["self_update"]
 
 [dependencies]
-jemallocator = "0.3.2"
+tikv-jemallocator = "0.4.3"
 serde_json = "1.0.33"
 itertools = "0.8.0"
 nom = "6"

--- a/src/bin/agrind.rs
+++ b/src/bin/agrind.rs
@@ -10,7 +10,7 @@ use std::io::{stdout, BufReader};
 use structopt::StructOpt;
 
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 use crate::InvalidArgs::{CantSupplyBoth, InvalidFormatString, InvalidOutputMode};
 use structopt::clap::ArgGroup;


### PR DESCRIPTION
[`jemallocator`](https://crates.io/crates/jemallocator) is no longer maintained (last commit was 3 years ago), and it fails to build on RISC-V environment. [`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) is a well-known and well-maintained successor of `jemallocator`.