### PR TITLE
Maintain ordering of columns when emitting aggregation JSON.

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -22,7 +22,7 @@ pub enum Row {
 /// Serde serializers are not allowed to emit nested serializations directly, so
 /// it's necesssary to create an intermediary type for each row, and to provide
 /// it with the columns to enable ordering.
-pub struct WrappedAggregateRow<'a> {
+pub(crate) struct WrappedAggregateRow<'a> {
     pub columns: &'a Vec<String>,
     pub data: &'a VMap,
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -2,7 +2,7 @@ use crate::operator::{EvalError, Expr, ValueRef};
 use chrono::{DateTime, Duration, Utc};
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
-use serde::ser::SerializeMap;
+use serde::ser::{SerializeMap, SerializeSeq};
 use serde::Serializer;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -18,10 +18,52 @@ pub enum Row {
     Record(Record),
 }
 
+/// Helper to allow for a custom serde Serializer for the rows in an Aggregate.
+/// Serde serializers are not allowed to emit nested serializations directly, so
+/// it's necesssary to create an intermediary type for each row, and to provide
+/// it with the columns to enable ordering.
+pub struct WrappedAggregateRow<'a> {
+    pub columns: &'a Vec<String>,
+    pub data: &'a VMap,
+}
+
+impl serde::Serialize for WrappedAggregateRow<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.columns.len()))?;
+        for k in self.columns {
+            map.serialize_entry(k, self.data.get(k).unwrap_or(&Value::None))?;
+        }
+        map.end()
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct Aggregate {
     pub columns: Vec<String>,
     pub data: Vec<VMap>,
+}
+
+// This custom serializer respects column order, whereas directly serializing
+// the `data` map would not.  (At least not while VMap is a HashMap.  serde_json
+// supports a "preserve_order" feature that uses the "indexmap" crate.  But
+// since we already have the info necessary for ordering, we use that.)
+impl serde::Serialize for Aggregate {
+    fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.data.len()))?;
+        for row in &self.data {
+            seq.serialize_element(&WrappedAggregateRow {
+                columns: &self.columns,
+                data: &row,
+            })?
+        }
+        seq.end()
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -125,7 +125,7 @@ impl Printer<data::Aggregate> for JsonPrinter {
     }
 
     fn final_print(&mut self, row: &Aggregate, _display_config: &DisplayConfig) -> String {
-        let mut o = serde_json::to_string(&row.data).unwrap();
+        let mut o = serde_json::to_string(&row).unwrap();
         o.push('\n');
         o
     }


### PR DESCRIPTION
Before this patch, the JsonPrinter for data:Aggregate asks serde_json to serialize its `Vec<VMap>` data field.  Because VMap is currently defined to be a HashMap, the ordering of keys in the map will effectively be random on a per-row basis.  Changing VMap to use an ordered map (and ensuring that the order keys are added in the desired order) would correct the ordering problem, but could have performance implications.

To address this problem, this patch implements a custom serde serializer for `data::Aggregate` and changes JsonPrinter to use it. Because serde Serializers are not allowed to directly nest objects, a new helper struct `WrappedAggregateRow` is introduced to provide a type that can both have a custom serializer attached as well as pass a borrowed reference to the columns.