### PR TITLE
Fix Windows (msvc) build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ extended-description = """Angle-grinder allows you to parse, aggregate, sum, ave
 default = []
 self-update = ["self_update"]
 
-[dependencies]
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5.0"
+
+[dependencies]
 serde_json = "1.0.33"
 itertools = "0.10.5"
 nom = "7.1.1"

--- a/src/bin/agrind.rs
+++ b/src/bin/agrind.rs
@@ -9,6 +9,7 @@ use std::io;
 use std::io::{stdout, BufReader};
 use thiserror::Error;
 
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
Fixes tkiv-jemalloc to be ignored for msvc builds, as recommended by its documentation.

Addresses #137 